### PR TITLE
Docs: Documentation Guide, Documentation Chat Mode, and runnable examples test harness (v3.2.1)

### DIFF
--- a/.github/chatmodes/documentation.md
+++ b/.github/chatmodes/documentation.md
@@ -1,0 +1,54 @@
+# Documentation Chat Mode
+
+This chat mode focuses on maintaining clear, consistent, and validated documentation.
+
+## Operating Rules
+
+1) Always load and follow `docs/documentation-guide.md`.
+2) Keep user docs lean (80/20) and avoid duplication; link to a single source of truth.
+3) Validate statements against the implementation:
+   - Prefer reading CLI help (e.g., `qxub --help` and subcommand `--help`).
+   - Consult code under `qxub/` for authoritative behavior.
+4) Prefer adding runnable examples to `docs/examples.md` using the `bash runnable` fence.
+5) After editing examples, ask the user to run:
+   - `tests/test_docs_examples.sh --list` then `--run` to validate snippets.
+6) For major behavior changes, remind to update release notes and relevant tutorials.
+7) Avoid documentation bloat:
+   - Update an existing document where possible rather than creating a new file.
+   - Only create new docs when explicitly requested or when a clear gap exists.
+   - If no obvious home, propose a target and seek clarification before proceeding.
+
+## Scope and Placement
+
+- Quick starts stay in the top-level `README.md` (under ~60 lines) and link into `docs/`.
+- User guides live in `docs/*.md` and `docs/tutorial/`. Dev architecture stays in `docs/dev/`.
+- Keep implementation detail out of user docs; summarize and link to dev docs when needed.
+
+## Runnable Examples Convention
+
+- Mark runnable shell examples as:
+
+  ```
+  ```bash runnable
+  # tags: hpc
+  qxub --help
+  ```
+  ```
+
+- Use tags (`hpc`, `slow`, etc.) to control the test runner.
+- Ensure commands are safe (prefer dry-run flags) and self-contained.
+
+## Consistency Checklist
+
+When updating docs for a feature:
+- [ ] Does `qxub --help` reflect the documented options and subcommands?
+- [ ] Are examples updated in `docs/examples.md` and correctly marked as runnable?
+- [ ] Are tutorials accurate for the updated flows?
+- [ ] Are dev docs updated if contracts/architecture changed?
+- [ ] Have you run `tests/test_docs_examples.sh` to validate runnable examples?
+
+## Authoring Notes
+
+- Use short paragraphs and code examples over long prose.
+- Prefer concrete commands that users can copy and try.
+- If the same topic appears in multiple places, consolidate to one page and link.

--- a/docs/documentation-guide.md
+++ b/docs/documentation-guide.md
@@ -1,0 +1,118 @@
+# qxub Documentation Guide
+
+This guide defines how we organize, write, and validate documentation across the project.
+It also establishes conventions for runnable examples and the “Documentation Chat Mode”.
+
+## Principles
+
+* Be lean and user-focused (80/20 rule).
+* Avoid duplication; prefer a single source of truth and link to it.
+* Keep quick start in the top-level `README.md` under ~60 lines.
+* Reflect reality: docs must match the current implementation and CLI help.
+* Runnable examples must be safe by default and easy to test automatically.
+
+### Avoid documentation bloat
+
+- Prefer updating an existing document over creating a new one.
+- Only create new documents when explicitly requested or when a clear, durable gap exists.
+- If there is no obvious home for a change, propose the target page (or a new page name) and seek clarification before proceeding.
+- Consolidate duplicate topics into a single canonical page and link to it from others.
+- Keep user docs concise; move deep implementation details to `docs/dev/`.
+
+## Documentation Structure
+
+* Top-level `README.md` (quick start)
+  * What qxub is, how to install, the most common one-liner, and links to deeper docs.
+
+* `docs/` (user docs)
+  * `README.md` – index of user docs.
+  * `examples.md` – the authoritative collection of common, runnable examples.
+  * `configuration.md` – config precedence, XDG paths, and essential options only.
+  * `aliases.md` – alias usage patterns.
+  * `platform_configuration.md` – platform definitions and queue selection rules.
+  * `remote-execution.md` – SSH/remote execution usage (emerging feature).
+  * `option-placement.md` – unified CLI structure and option placement.
+  * `shortcuts.md`, `smart-quotes.md` – focused user topics.
+  * `tutorial/` – step-by-step guides (can include runnable snippets when feasible).
+
+* `docs/dev/` (developer docs)
+  * Architecture and design references (schemas, threading, package structure).
+  * Non-runnable deep dives kept concise; update when implementation changes.
+
+* `docs/RELEASE_NOTES_*.md` (release notes)
+
+* `examples/` (worked scenarios)
+  * Optional scripts that demonstrate end-to-end flows; can be referenced by docs.
+
+* Docstrings
+  * Keep short, precise, and include doctest examples when helpful.
+
+## Runnable Examples Convention
+
+We automatically extract and test runnable examples from Markdown files.
+
+* Mark runnable code blocks with a fenced header containing both the shell language and the `runnable` tag:
+
+  ```
+  ```bash runnable
+  qxub --help
+  ```
+  ```
+
+* Allowed languages: `bash`, `sh`.
+* Optional tags: Add a first-line comment to categorize blocks, e.g.:
+  * `# tags: hpc` – requires access to an HPC environment; skipped by default.
+  * `# tags: slow` – long-running; skipped by default.
+  * `# tags: destructive` – contains potentially destructive operations; rejected.
+
+Safety rules enforced by the test runner:
+* Blocks containing obviously destructive commands are rejected (e.g., `rm -rf`, `sudo`, `mkfs`, `dd if=`).
+* By default, blocks tagged `hpc` or `slow` are listed but skipped unless explicitly enabled.
+* Prefer dry-run flags in examples where available.
+
+Scope for extraction:
+* Top-level `README.md` and files under `docs/` (including `docs/tutorial/`).
+* Developer docs under `docs/dev/` are not scanned by default.
+
+## Validation Tooling
+
+Run the example tests with:
+
+```bash
+tests/test_docs_examples.sh --list       # enumerate runnable snippets
+tests/test_docs_examples.sh --run        # run safe, untagged snippets
+tests/test_docs_examples.sh --run --include-tag hpc  # opt-in categories
+```
+
+Guidelines for authors:
+* Add runnable examples to `docs/examples.md` when feasible.
+* Keep examples self-contained and short.
+* Prefer safe defaults and dry runs.
+* After updating docs or CLI behavior, run the example tests.
+
+## Update Checklist (for PRs)
+
+When adding or changing functionality:
+1. Update user docs (examples, options, configuration) as needed.
+2. Update tutorials only if user flows change.
+3. Update dev docs if architecture or contracts change.
+4. Add/adjust runnable examples and run `tests/test_docs_examples.sh`.
+5. If docstrings changed, ensure doctests still pass (when enabled in CI).
+
+## Documentation Chat Mode Contract
+
+When using Documentation Chat Mode:
+* Always consult this guide first to determine where content belongs.
+* Keep responses lean and consistent with the structure above.
+* Validate claims against:
+  * CLI help (`qxub --help`, subcommand `--help` where applicable), and
+  * The files under `qxub/` as the source of truth.
+* Prefer updating `docs/examples.md` for examples.
+* For runnable examples, include the `bash runnable` fence and appropriate tags.
+* Suggest running `tests/test_docs_examples.sh` to verify examples.
+
+Disallowed patterns:
+* Duplicating content across multiple pages without a clear reason.
+* Including long implementation details in user docs (link to dev docs instead).
+
+This guide is the canonical reference for documentation organization, conventions, and validation in qxub.


### PR DESCRIPTION
This PR introduces a lean, testable documentation workflow.

Highlights
- Add Documentation Guide (`docs/documentation-guide.md`) with principles (80/20), structure, runnable examples conventions, and an anti-bloat policy (prefer updating existing docs; propose new only when necessary or explicitly requested).
- Add Documentation Chat Mode (`.github/chatmodes/documentation.md`) to steer docs-focused changes: consistency checks, placement guidance, and the anti-bloat rules.
- Add runnable examples test harness (`tests/test_docs_examples.sh`) to extract and run fenced blocks marked as ```bash runnable (with safe defaults, denylist, and optional tags like `hpc`, `slow`).
- Link the guide from `docs/README.md` via a new "Start Here" section.

Why
- Keep docs accurate, lean, and consistent with the implementation.
- Make runnable examples first-class and continuously verifiable.
- Provide a clear set of rules for docs contributions and reviews.

How to use
```bash
# list snippets discovered in docs (excluding docs/dev/*)
tests/test_docs_examples.sh --list

# run safe, untagged snippets
tests/test_docs_examples.sh --run

# opt-in categories (e.g., hpc)
tests/test_docs_examples.sh --run --include-tag hpc
```

Notes
- The snippet runner blocks destructive commands (rm -rf, sudo, mkfs, dd if=, etc.).
- Tagged blocks are skipped by default; use --include-tag to opt in.
- Authors should prefer adding runnable examples to `docs/examples.md` when feasible.

Follow-ups (tracked in Issue #20)
- CI integration to run the examples script on PRs.
- Enable doctest for docstrings with sensible exclusions.
- Optional CONTRIBUTING.md hook or PR checklist referencing the guide and script.
