### PR TITLE
v3.2.4: Fix conda environment validation for path-based environments

### DIFF
--- a/qxub/__init__.py
+++ b/qxub/__init__.py
@@ -9,7 +9,7 @@ v2.3 adds parallel job execution with --terse output and 'qxub monitor' for pipe
 
 # __init__.py
 
-__version__ = "3.2.3"
+__version__ = "3.2.4"
 
 # Import main CLI
 from . import cli as cli_module

--- a/qxub/jobscripts/qconda.pbs
+++ b/qxub/jobscripts/qconda.pbs
@@ -132,7 +132,9 @@ if ! conda activate $env 2>&1; then
 fi
 
 # Verify that the environment was actually activated
-if [ "$CONDA_DEFAULT_ENV" != "$env" ]; then
+# Note: CONDA_DEFAULT_ENV may be just the name or a full path depending on conda configuration
+ACTIVATED_ENV_NAME=$(basename "$CONDA_DEFAULT_ENV")
+if [ "$ACTIVATED_ENV_NAME" != "$env" ]; then
     echo "❌ ERROR: Conda environment activation failed - expected '$env', got '$CONDA_DEFAULT_ENV'"
     echo "1" > "$STATUS_DIR/final_exit_code_${PBS_JOBID:-unknown}"
     echo "$(date -Iseconds)" >> "$STATUS_DIR/final_exit_code_${PBS_JOBID:-unknown}"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="qxub",
-    version="3.2.3",
+    version="3.2.4",
     author="John Reeves",
     author_email="j.reeves@garvan.org.au",
     description="Simplified job submission to HPC",


### PR DESCRIPTION
## Summary

Fixes conda environment activation validation to handle path-based conda environments. This resolves an issue where jobs would fail during environment activation when conda stores environments with full paths.

## Problem

When conda environments are stored in custom locations (e.g., `/g/data/a56/conda/envs/usr/jr9959/`), the `CONDA_DEFAULT_ENV` variable contains the full path instead of just the environment name:

```
❌ ERROR: Conda environment activation failed - expected 'mkseurat_5.1', got '/g/data/a56/conda/envs/usr/jr9959/mkseurat_5.1'
```

This occurs when users configure conda with custom `envs_dirs` in their `.condarc`, which is common on shared HPC systems to manage personal environments in project storage.

## Solution

Extract the basename from `CONDA_DEFAULT_ENV` before comparing to the expected environment name:

```bash
# Before (line 133):
if [ "$CONDA_DEFAULT_ENV" != "$env" ]; then

# After:
ACTIVATED_ENV_NAME=$(basename "$CONDA_DEFAULT_ENV")
if [ "$ACTIVATED_ENV_NAME" != "$env" ]; then
```

This handles both cases:
- Standard conda environments: `CONDA_DEFAULT_ENV="myenv"` → basename → `"myenv"` ✅
- Path-based environments: `CONDA_DEFAULT_ENV="/path/to/myenv"` → basename → `"myenv"` ✅

## Changes

- **`qxub/jobscripts/qconda.pbs`**: Updated environment validation to use basename
- **`qxub/__init__.py`**: Version bump to 3.2.4
- **`setup.py`**: Version bump to 3.2.4

## Testing

Manual testing confirms the fix resolves the activation validation error for path-based conda environments while maintaining compatibility with standard environments.

## Impact

This is a bug fix that unblocks users who:
- Have custom `envs_dirs` configured in `.condarc`
- Store conda environments in project directories
- Use shared HPC systems with custom conda configurations

No breaking changes - maintains full backward compatibility with standard conda installations.