### PR TITLE
fix: record history before terse mode early return (v3.4.3)

### DIFF
--- a/qxub/__init__.py
+++ b/qxub/__init__.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "3.4.2"
+__version__ = "3.4.3"
 
 # Import main CLI
 from . import cli as cli_module

--- a/qxub/execution/context.py
+++ b/qxub/execution/context.py
@@ -201,6 +201,20 @@ def execute_unified(
     except Exception as e:
         logging.debug("Failed to log job submission: %s", e)
 
+    # Log execution to history system (must happen before terse mode early return)
+    try:
+        # Prepare file paths for history
+        file_paths = {
+            "out": ctx_obj["out"],
+            "err": ctx_obj["err"],
+            "joblog": ctx_obj.get("joblog"),  # May be None initially
+        }
+        history_manager.log_execution(
+            ctx, success=True, job_id=job_id, file_paths=file_paths
+        )
+    except Exception as e:
+        logging.debug("Failed to log execution history: %s", e)
+
     # Handle terse mode - emit job ID and return immediately (for pipeline use)
     if ctx_obj.get("terse", False):
         click.echo(job_id)
@@ -215,20 +229,6 @@ def execute_unified(
 
         success_msg = f"✅ Job submitted successfully! Job ID: {job_id}"
         print_status(success_msg, final=True)
-
-    # Log execution to history system
-    try:
-        # Prepare file paths for history
-        file_paths = {
-            "out": ctx_obj["out"],
-            "err": ctx_obj["err"],
-            "joblog": ctx_obj.get("joblog"),  # May be None initially
-        }
-        history_manager.log_execution(
-            ctx, success=True, job_id=job_id, file_paths=file_paths
-        )
-    except Exception as e:
-        logging.debug("Failed to log execution history: %s", e)
 
     # All modes now continue to monitoring (removed the quiet mode early return)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="qxub",
-    version="3.4.2",
+    version="3.4.3",
     author="John Reeves",
     author_email="j.reeves@garvan.org.au",
     description="Simplified job submission to HPC",


### PR DESCRIPTION
## Summary

Fixes a bug where jobs submitted with `--terse` mode were not being recorded in execution history.

## Problem

The `--terse` mode was returning immediately after job submission without recording execution history. This caused:
- Jobs submitted with `--terse` not appearing in `qxub history executions`
- Recipe deduplication not tracking terse job submissions  
- Job file paths (stdout/stderr) not being recorded for terse jobs

## Root Cause

In `qxub/execution/context.py`, the terse mode early return happened **before** the `log_execution()` call:

```python
# Handle terse mode - emit job ID and return immediately
if ctx_obj.get("terse", False):
    click.echo(job_id)
    return  # ← Returns before history is logged!

# Log execution to history system ← Never reached for terse mode
history_manager.log_execution(...)
```

## Fix

Moved the `log_execution()` call to happen **before** the terse mode check:

```python
# Log execution to history system (must happen before terse mode early return)
history_manager.log_execution(...)

# Handle terse mode - emit job ID and return immediately
if ctx_obj.get("terse", False):
    click.echo(job_id)
    return
```

## Testing

Tested by submitting jobs with `--terse` and verifying they appear in `qxub history executions`:

```bash
$ JOB_ID=$(qxub exec --terse -- echo "test")
$ qxub history executions --limit 1
# ✅ Shows the terse job with correct job ID
```

## Version

Bumps version to 3.4.3 (both `qxub/__init__.py` and `setup.py`).