### PR TITLE
fix: qxtat check --snakemake returns 'running' for completed jobs

### DIFF
--- a/qxub/resources/tracker.py
+++ b/qxub/resources/tracker.py
@@ -529,6 +529,21 @@ class ResourceTracker:
             logging.debug("Failed to update job status for %s: %s", job_id, e)
             return False
 
+    def update_job_exit_code(self, job_id: str, exit_code: int) -> bool:
+        """Update the exit code for a job."""
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                conn.execute(
+                    "UPDATE job_resources SET exit_code=? WHERE job_id=?",
+                    (exit_code, job_id),
+                )
+                conn.commit()
+            logging.debug("Updated job %s exit_code to %s", job_id, exit_code)
+            return True
+        except Exception as e:
+            logging.debug("Failed to update exit code for %s: %s", job_id, e)
+            return False
+
     def get_job_status(self, job_id: str) -> Optional[Dict[str, Any]]:
         """Get current status of a specific job."""
         try:


### PR DESCRIPTION
Fixes #49

## Problem

When `qxub exec --terse` is used (as in Snakemake profiles), qxub exits immediately after submission without monitoring the job. The internal SQLite database is never updated beyond `running`, so `qxtat check --snakemake <job_id>` always returns `running` — even after the job finishes on PBS.

## Solution

In `qxub status check`, when the DB reports an active state (`submitted` or `running`), fall back to the **file-based status** written by the jobscript:

- `status/final_exit_code_{job_id}` — written on completion (exit 0 → `C`, non-zero → `F`)
- `status/job_started_{job_id}` — written when the job starts

This reuses the existing `job_status_from_files()` function already used by `qxub monitor`, so no new logic is needed and **no qstat calls are made**.

Once a terminal state is detected from the files, the DB is updated (`status` + `exit_code`) so all subsequent calls are served directly from the database.

## Changes

- `qxub/status_cli.py` — call `job_status_from_files()` as fallback in `check` command; persist resolved state back to DB
- `qxub/resources/tracker.py` — add `update_job_exit_code()` method