### PR TITLE
feat(interactive): show mem, cpus and storage in qxi startup summary

### DIFF
--- a/qxub/interactive_cli.py
+++ b/qxub/interactive_cli.py
@@ -1372,10 +1372,16 @@ def interactive_cli(
     # Execute interactive session
     click.echo("🚀 Starting interactive session...")
     click.echo(f"   {context_desc}")
-    click.echo(f"   Queue: {queue}")
+    click.echo(f"   Queue:   {queue}")
     click.echo(f"   Runtime: {runtime}")
+    if mem:
+        click.echo(f"   Memory:  {mem}")
+    if cpus:
+        click.echo(f"   CPUs:    {cpus}")
+    if storage:
+        click.echo(f"   Storage: {storage}")
     if tmux_session:
-        click.echo(f"   Tmux: {tmux_session}")
+        click.echo(f"   Tmux:    {tmux_session}")
     click.echo("")
 
     # Write the initialization script to a temporary file


### PR DESCRIPTION
## Summary

The `qxi` startup message previously only reported queue and runtime. This PR extends it to also display memory, CPUs, and storage when those values are set.

## Before

```
🚀 Starting interactive session...
   conda: myenv
   Queue: normal
   Runtime: 01:00:00
```

## After

```
🚀 Starting interactive session...
   conda: myenv
   Queue:   normal
   Runtime: 01:00:00
   Memory:  8GB
   CPUs:    4
   Storage: scratch/a56+scratch/v48
```

Values are only shown when set (optional fields remain suppressed if absent). Labels are aligned for readability.

The verbose/dry-run block already showed all of these values — this aligns the concise startup summary with that output.