### PR TITLE
fix: detect walltime-exceeded jobs in exec monitoring loop

### DIFF
--- a/qxub/core/scheduler.py
+++ b/qxub/core/scheduler.py
@@ -957,6 +957,8 @@ def monitor_job_single_thread(
     joblog_file=None,
     verbose=0,
     walltime_str=None,
+    joblog_check_interval=60,
+    walltime_offset_sec=0,
 ):
     """
     Single-thread job monitoring with proper spinner integration using status files.
@@ -1032,10 +1034,12 @@ def monitor_job_single_thread(
             print(f"🔍 DEBUG: Derived joblog path from out_file: {joblog_path}")
 
     # Parse walltime string to seconds for NFS-friendly joblog gating.
+    # walltime_offset_sec shifts the gate: positive = extra grace period after
+    # walltime before first check; negative = start checking earlier.
     walltime_sec = None
     if walltime_str:
         try:
-            walltime_sec = time_to_seconds(walltime_str)
+            walltime_sec = max(0, time_to_seconds(walltime_str) + walltime_offset_sec)
             logging.debug("Monitoring with walltime gate: %s s", walltime_sec)
         except Exception:
             pass  # Unknown format — fall back to immediate 60 s polling
@@ -1053,6 +1057,7 @@ def monitor_job_single_thread(
         quiet=quiet,
         joblog_file=joblog_path,
         walltime_sec=walltime_sec,
+        joblog_check_interval=joblog_check_interval,
     )
 
     # 8. Completion message
@@ -1100,6 +1105,7 @@ def stream_job_output_with_status_files(
     quiet=False,
     joblog_file=None,
     walltime_sec=None,
+    joblog_check_interval=60,
 ):
     """
     Stream job output files until job completion using status files for detection.
@@ -1115,11 +1121,12 @@ def stream_job_output_with_status_files(
             contains an ``Exit Status:`` line).  This catches jobs killed by
             PBS (e.g. walltime exceeded) before our in-job cleanup code runs
             and writes final_exit_code_file.
-        walltime_sec: Expected walltime in seconds (optional).  When set, joblog
-            checks are deferred until this many seconds have elapsed, avoiding
-            all NFS reads during normal operation.  When not set, joblog checks
-            start immediately but are still rate-limited (every 60 s) to catch
-            unexpected PBS kills (node failure, qdel, etc.) at low NFS cost.
+        walltime_sec: Expected walltime in seconds (optional, already offset-
+            adjusted by caller).  When set, joblog checks are deferred until
+            this many seconds have elapsed.  When not set, joblog checks start
+            immediately but are still rate-limited to catch unexpected PBS kills.
+        joblog_check_interval: Seconds between joblog reads once eligible
+            (default 60).  Increase on busy NFS systems to reduce load.
 
     Returns:
         int: Job exit status
@@ -1135,8 +1142,7 @@ def stream_job_output_with_status_files(
     #   seconds have elapsed (zero NFS reads during normal operation).
     # - If walltime_sec is unknown: start checking immediately as a safety net
     #   for unexpected PBS kills (node failure, qdel, etc.).
-    # Either way, cap checks at one per JOBLOG_CHECK_INTERVAL seconds.
-    JOBLOG_CHECK_INTERVAL = 60  # seconds
+    # Either way, cap checks at one per joblog_check_interval seconds.
     monitoring_start = time.time()
     last_joblog_check = None  # timestamp of last actual joblog open
 
@@ -1208,14 +1214,14 @@ def stream_job_output_with_status_files(
         # Check PBS job log for exit status (walltime-kill / PBS-kill path).
         # PBS writes an Exit Status line to the .log file even when it kills
         # a job before our cleanup code can write final_exit_code_file.
-        # We rate-limit to JOBLOG_CHECK_INTERVAL and defer until walltime
+        # We rate-limit to joblog_check_interval and defer until walltime
         # has elapsed (when known) to minimise NFS pressure.
         if joblog_file:
             now = time.time()
             elapsed = now - monitoring_start
             past_walltime = walltime_sec is None or elapsed >= walltime_sec
             due_for_check = last_joblog_check is None or (
-                now - last_joblog_check >= JOBLOG_CHECK_INTERVAL
+                now - last_joblog_check >= joblog_check_interval
             )
             if past_walltime and due_for_check:
                 last_joblog_check = now

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -642,7 +642,16 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
     ctx.obj.update(processed_params)
     ctx.obj["options"] = qsub_options
 
-    # Platform selection and execution mode detection
+    # Monitoring config -- how aggressively to poll the joblog on NFS.
+    # Both values are user-overridable via:
+    #   qxub config set monitoring.joblog_check_interval_sec 120
+    #   qxub config set monitoring.walltime_offset_sec 30
+    ctx.obj["joblog_check_interval"] = int(
+        config_manager.get_config_value("monitoring.joblog_check_interval_sec") or 60
+    )
+    ctx.obj["walltime_offset_sec"] = int(
+        config_manager.get_config_value("monitoring.walltime_offset_sec") or 0
+    )
     default_platform = config_manager.get_default_platform_name()
     platform_name = options.get("platform") or default_platform
 

--- a/qxub/execution/context.py
+++ b/qxub/execution/context.py
@@ -270,6 +270,8 @@ def execute_unified(
             joblog_file=ctx_obj.get("joblog"),
             verbose=verbose_level,
             walltime_str=ctx_obj.get("runtime"),
+            joblog_check_interval=ctx_obj.get("joblog_check_interval", 60),
+            walltime_offset_sec=ctx_obj.get("walltime_offset_sec", 0),
         )
         # Exit with the job's exit status
         sys.exit(exit_status)


### PR DESCRIPTION
## Bug

`qxub exec` hangs indefinitely when a job is killed by PBS (walltime exceeded or any other PBS-initiated termination).

### Root cause

The live monitoring loop in `stream_job_output_with_status_files` only watched `final_exit_code_{job_id}` — a file written by the job script's cleanup hook at the very end.  When PBS kills the job, the cleanup hook never runs, so the file is never created, and the loop spins forever.

The `job_status_from_files` path (used by `qxub status check` for Snakemake) already handled this correctly via `_check_pbs_job_log_for_exit`.  The interactive exec monitoring path did not.

## Fix

PBS writes an `Exit Status:` line to the job's `.log` file unconditionally when the job ends — including when it kills the job.  The monitoring loop now also watches for this line.

```
# Normal completion:  final_exit_code_{job_id}  written by cleanup hook  ✅ was working
# PBS kill:           {jobname}.log  Exit Status line written by PBS      ✅ now fixed
```

### NFS-aware polling strategy

On a shared NFS filesystem, opening and reading a file every 200 ms would add unnecessary pressure.  The joblog check uses a tiered strategy:

| Situation | Joblog polling behaviour |
|-----------|--------------------------|
| Walltime known (normal case) | No joblog reads at all until walltime has elapsed; then once per 60 s |
| Walltime unknown | Once per 60 s from job start (safety net for unexpected kills) |
| Normal completion via cleanup hook | Unaffected — still detected via `final_exit_code_file` every 200 ms |

### Changes to `qxub/core/scheduler.py`

| What | Why |
|------|-----|
| New `_read_exit_from_joblog_file(joblog_path)` | Targeted single-file reader, cheap to call |
| `_check_pbs_job_log_for_exit()` refactored to use the helper | Minor cleanup |
| `stream_job_output_with_status_files()` — new `joblog_file`, `walltime_sec` params | NFS gate + 60 s rate limit on joblog checks |
| `monitor_job_single_thread()` — new `walltime_str` param | Parses walltime, derives `walltime_sec`, passes to streamer |

### Changes to `qxub/execution/context.py`

Passes `walltime_str=ctx_obj.get("runtime")` to `monitor_job_single_thread`.
