### PR TITLE
ci: adopt feature → dev → main branching model

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -168,7 +168,45 @@ qxub config shortcut show "dvc pull"  # Will fail or use wrong version
 - **After implementation**: Update affected documentation immediately
 - **Quality check**: Ensure docs remain concise and user-focused (no implementation details)
 
-### Git Workflow - CRITICAL
+### Branching Model — feature → dev → main
+
+The project uses a **three-tier branching model**:
+
+| Branch | Purpose | Merges into | CI intensity |
+|--------|---------|-------------|--------------|
+| `feature/*`, `fix/*` | Individual changes | `dev` | Lightweight (lint + format) |
+| `dev` | Integration & testing | `main` | Full (lint + format + self-hosted runner tests) |
+| `main` | Stable releases | — | Full + auto-release if version bumped |
+
+#### Day-to-day workflow
+
+```bash
+# 1. Start work from dev
+git checkout dev && git pull
+git checkout -b fix/my-bug   # or feature/my-feature
+
+# 2. Work, commit, push
+git add qxub/some_file.py
+git commit -m "fix: description"
+git push origin fix/my-bug
+
+# 3. Open PR targeting dev  ← lightweight CI
+#    Merge when formatting + pylint pass
+
+# 4. Periodically: create a dev → main PR for release
+#    - Bump version in qxub/__init__.py + setup.py
+#    - Full self-hosted runner tests run automatically
+#    - Merge triggers GitHub Release + tag creation
+```
+
+#### Rules
+
+- **Feature/fix PRs always target `dev`**, never `main` directly.
+- **Version bumps happen only in the dev → main PR**, not in feature branches.
+- **`main` always reflects the latest release.** Every merge into `main` should be releasable.
+- **`dev` may contain unreleased work.** It is the integration branch.
+
+### Git Hygiene
 
 **ALWAYS stage files consciously. NEVER use `git add .`**
 
@@ -187,20 +225,12 @@ git add .
 git add -A
 ```
 
-**Why**: Blanket staging creates zombie files, commits temp scripts, and bundles unrelated changes.
-
 **Run pre-commit checks manually before committing:**
 
 ```bash
-# Run pre-commit on staged files (fast, only checks what you're committing)
-pre-commit run
-
-# This catches formatting issues before commit
-# Fix any issues, then re-stage the fixed files
-# Then commit normally
+pre-commit run        # checks staged files
+# Fix any issues, re-stage, then commit
 ```
-
-This ensures your commit succeeds on the first try. The commit hook then acts as a final safety check.
 
 ### Refactoring Workflow
 
@@ -241,17 +271,17 @@ When bumping versions for a new release, **ALWAYS update version numbers in BOTH
 1. **`qxub/__init__.py`** - Contains `__version__ = "x.y.z"`
 2. **`setup.py`** - Contains `version="x.y.z"` in the setup() call
 
+Version bumps happen **only in the dev → main merge PR**, not in feature branches:
+
 ```bash
-# Example version bump workflow:
-# 1. Edit qxub/__init__.py
-__version__ = "3.2.3"
-
-# 2. Edit setup.py
-version="3.2.3"
-
-# 3. Commit both together
+# In the dev branch, just before creating the dev → main PR:
+git checkout dev
+# Edit qxub/__init__.py  →  __version__ = "3.5.0"
+# Edit setup.py           →  version="3.5.0"
 git add qxub/__init__.py setup.py
-git commit -m "Bump version to 3.2.3"
+git commit -m "Bump version to 3.5.0"
+git push origin dev
+# Then open PR: dev → main
 ```
 
 **Critical**: The GitHub release workflow reads from `setup.py`, so both files must match!

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,19 @@
 
 This directory contains CI workflows for qxub testing and release automation.
 
+## Branching Model & CI Tiers
+
+The project uses a **feature → dev → main** branching model with tiered CI:
+
+| CI tier | Workflows | Trigger | Runner |
+|---------|-----------|---------|--------|
+| **Lightweight** | `formatting.yml`, `pylint.yml` | Every push & PR | GitHub-hosted |
+| **Full** | `runner-connection-test.yml`, `runner-validation.yml` | Push to `dev`/`main`, PRs targeting `main` | Self-hosted |
+| **Release** | `release.yml` | Push to `main` (version bump) | GitHub-hosted |
+
+**Day-to-day**: feature/fix branches open PRs against `dev` → only formatting + pylint run.
+**Release cycle**: `dev → main` PRs trigger full self-hosted runner tests. Merging creates a GitHub Release when the version is bumped.
+
 ## Active Workflows
 
 ### Code Quality (GitHub Runners)

--- a/.github/workflows/runner-connection-test.yml
+++ b/.github/workflows/runner-connection-test.yml
@@ -5,10 +5,10 @@ on:
   push:
     branches:
       - main
-      - 'release/**'  # All release branches
+      - dev
   pull_request:
     branches:
-      - main
+      - main  # Only run heavy tests on dev → main PRs
 
 jobs:
   test-runner-qxub:

--- a/.github/workflows/runner-validation.yml
+++ b/.github/workflows/runner-validation.yml
@@ -5,10 +5,10 @@ on:
   push:
     branches:
       - main
-      - 'release/**'  # All release branches
+      - dev
   pull_request:
     branches:
-      - main
+      - main  # Only run heavy tests on dev → main PRs
 
 jobs:
   validate-runner-setup:


### PR DESCRIPTION
# Adopt feature → dev → main branching model

Introduces a three-tier branching workflow with tiered CI intensity:

## Changes

### Copilot Instructions (`.github/copilot-instructions.md`)
- Replace flat "Git Workflow" section with **Branching Model** (feature → dev → main)
- Document day-to-day workflow, rules, and version bump process
- Streamline Git Hygiene section (remove redundant explanations)

### CI Workflows
- **`runner-validation.yml`** / **`runner-connection-test.yml`**: Replace `release/**` trigger with `dev` branch; heavy self-hosted tests now run on:
  - Push to `main` or `dev`
  - PRs targeting `main` (i.e., dev → main releases)
- **`formatting.yml`** / **`pylint.yml`**: Unchanged (already lightweight, run on all push/PR)
- **`release.yml`**: Unchanged (triggers on push to `main` with version bump)

### Workflows README
- Add CI tier table showing which workflows run when

## CI Tier Summary

| Tier | Workflows | Trigger | Runner |
|------|-----------|---------|--------|
| Lightweight | formatting, pylint | Every push & PR | GitHub-hosted |
| Full | runner-connection-test, runner-validation | `dev`/`main` push, PRs → `main` | Self-hosted |
| Release | release | `main` push (version bump) | GitHub-hosted |

## Next step after merge
Create the `dev` branch from `main` so the new workflow is operational.