### PR TITLE
fix: make qxtat check resilient to transient DB failures (#61)

### DIFF
--- a/qxub/resources/tracker.py
+++ b/qxub/resources/tracker.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import sqlite3
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
@@ -70,6 +71,21 @@ def _resolve_tracker_db_path() -> Path:
     return resolved
 
 
+# Default timeout (seconds) for all sqlite connections.  The shared DB on
+# /g/data can experience lock contention when many concurrent qxtat check
+# processes race on the same file.  30 s is generous enough to ride out
+# filesystem latency spikes on Gadi /scratch.
+_SQLITE_TIMEOUT = 30
+
+
+class DatabaseError(Exception):
+    """Raised when a sqlite query fails due to a transient or I/O error.
+
+    Distinct from a *missing row* (which returns ``None``).  Callers can
+    catch this to distinguish "DB unreachable" from "job not found".
+    """
+
+
 class ResourceTracker:
     """Simple resource tracking focused on efficiency metrics."""
 
@@ -83,7 +99,10 @@ class ResourceTracker:
 
     def _init_database(self):
         """Initialize SQLite database with resource tracking table."""
-        with sqlite3.connect(self.db_path) as conn:
+        with sqlite3.connect(self.db_path, timeout=_SQLITE_TIMEOUT) as conn:
+            # WAL mode allows concurrent readers even during writes,
+            # eliminating most lock-contention issues.
+            conn.execute("PRAGMA journal_mode=WAL")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS job_resources (
@@ -887,23 +906,45 @@ class ResourceTracker:
         return filled
 
     def get_job_status(self, job_id: str) -> Optional[Dict[str, Any]]:
-        """Get current status of a specific job."""
-        try:
-            with sqlite3.connect(self.db_path) as conn:
-                conn.row_factory = sqlite3.Row
-                cursor = conn.execute(
-                    """
-                    SELECT job_id, status, command, submitted_at, started_at,
-                           completed_at, last_status_update, exit_code, joblog_path
-                    FROM job_resources WHERE job_id=?
-                    """,
-                    (job_id,),
+        """Get current status of a specific job.
+
+        Returns ``None`` when the job is genuinely not in the database.
+        Raises :class:`DatabaseError` on transient sqlite failures so the
+        caller can distinguish "not found" from "DB unreachable".
+
+        Retries up to 3 times with exponential backoff to tolerate
+        filesystem latency spikes and lock contention.
+        """
+        last_exc: Optional[Exception] = None
+        for attempt in range(3):
+            try:
+                with sqlite3.connect(self.db_path, timeout=_SQLITE_TIMEOUT) as conn:
+                    conn.row_factory = sqlite3.Row
+                    cursor = conn.execute(
+                        """
+                        SELECT job_id, status, command, submitted_at, started_at,
+                               completed_at, last_status_update, exit_code, joblog_path
+                        FROM job_resources WHERE job_id=?
+                        """,
+                        (job_id,),
+                    )
+                    row = cursor.fetchone()
+                    return dict(row) if row else None
+            except Exception as e:  # pylint: disable=broad-except
+                last_exc = e
+                logging.debug(
+                    "get_job_status attempt %d failed for %s: %s",
+                    attempt + 1,
+                    job_id,
+                    e,
                 )
-                row = cursor.fetchone()
-                return dict(row) if row else None
-        except Exception as e:
-            logging.debug("Failed to get job status for %s: %s", job_id, e)
-            return None
+                if attempt < 2:
+                    time.sleep(0.5 * (2**attempt))  # 0.5 s, 1 s
+
+        # All retries exhausted — raise so the caller knows the DB failed.
+        raise DatabaseError(
+            f"Failed to query job status for {job_id} after 3 attempts: {last_exc}"
+        ) from last_exc
 
     def get_jobs_by_status(
         self, status: str = None, limit: int = None

--- a/qxub/status_cli.py
+++ b/qxub/status_cli.py
@@ -5,6 +5,7 @@ Provides the `qxub status` command for viewing job status without qstat polling.
 """
 
 import json
+import logging
 import sys
 from datetime import datetime, timedelta
 
@@ -15,6 +16,7 @@ from rich.table import Table
 from .core.scheduler import job_status_from_files
 from .queue import is_virtual_id, resolve_virtual_id
 from .resources import resource_tracker
+from .resources.tracker import DatabaseError
 
 console = Console()
 
@@ -274,9 +276,33 @@ def check(job_id, output_format, snakemake):
         job_id = f"{job_id}.gadi-pbs"
 
     # Get job status from database
-    job_info = resource_tracker.get_job_status(job_id)
+    try:
+        job_info = resource_tracker.get_job_status(job_id)
+    except DatabaseError as exc:
+        # Transient DB failure — for snakemake mode, report "running" so the
+        # workflow engine retries instead of aborting.  For other formats,
+        # surface the error but still exit 0 to avoid false-positive failures.
+        logging.debug("Database error during status check: %s", exc)
+        if output_format == "snakemake":
+            print("running")
+            return
+        if output_format == "json":
+            print(
+                json.dumps(
+                    {"error": "database temporarily unavailable", "job_id": job_id}
+                )
+            )
+        else:
+            sys.stderr.write(f"qxub: database temporarily unavailable for {job_id}\n")
+        sys.exit(1)
 
     if not job_info:
+        # Job genuinely not found — for snakemake mode, assume it is still
+        # queued/pending (recently submitted jobs may not have been committed
+        # to the DB yet).  This avoids Snakemake aborting the entire workflow.
+        if output_format == "snakemake":
+            print("running")
+            return
         if output_format == "json":
             print(json.dumps({"error": "Job not found", "job_id": job_id}))
         else:


### PR DESCRIPTION
# Fix: Make `qxtat check` resilient to transient DB failures

Closes #61

## Problem

`qxtat check --snakemake` exits with code 1 whenever the job isn't found in the database, causing Snakemake to abort the entire workflow. This happens due to:
- SQLite lock contention from concurrent status checks
- Submission race (status check fires before DB write commits)
- Filesystem latency spikes on Gadi /scratch

## Changes

### `qxub/resources/tracker.py`
- **Retry with backoff**: `get_job_status()` retries 3 times with exponential backoff (0.5s, 1s)
- **Increased sqlite timeout**: 5s → 30s via `_SQLITE_TIMEOUT` constant
- **WAL journal mode**: `PRAGMA journal_mode=WAL` in `_init_database()` for concurrent reader/writer support
- **`DatabaseError` exception**: New exception class to distinguish "DB unreachable" from "job not found" (`None`)

### `qxub/status_cli.py`
- **Snakemake resilience**: Unknown jobs return `running` (exit 0) instead of error (exit 1) — Snakemake will simply poll again
- **DB error handling**: `DatabaseError` caught separately; snakemake mode returns `running`, other formats report the transient error
- Non-snakemake formats (`json`, `exitcode`) still exit 1 for missing jobs

## Testing

- WAL mode verified on new databases
- Missing job returns `None` (not `DatabaseError`)
- Unreachable DB raises `DatabaseError` after 3 retries
- `qxtat check --snakemake 999999.gadi-pbs` → `running`, exit 0
- `qxtat check --format json 999999.gadi-pbs` → error JSON, exit 1
- All existing tests pass (8/8 config tests)