### PR TITLE
fix: use named loggers instead of root logger throughout qxub

### DIFF
--- a/qxub/__init__.py
+++ b/qxub/__init__.py
@@ -20,7 +20,13 @@ try:
 except ImportError:
     pass
 
-__version__ = "3.5.0.dev2"
+__version__ = "3.5.0.dev3"
+
+# Library-standard NullHandler: prevents "No handler found" warnings and
+# avoids triggering basicConfig() when qxub is used as a library.
+import logging
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # Import main CLI
 from . import cli as cli_module
@@ -29,11 +35,8 @@ qxub = cli_module.qxub
 
 # Import remote execution components (v3.3+)
 try:
-    from .remote import (  # noqa: F401
-        PlatformRemoteExecutor,
-        RemoteExecutionError,
-        build_remote_command,
-    )
+    from .remote import PlatformRemoteExecutor  # noqa: F401
+    from .remote import RemoteExecutionError, build_remote_command
 
     __all__ = [
         "qxub",
@@ -57,19 +60,14 @@ from .core import scheduler  # noqa: F401,E402
 try:
     # Import key resource utilities for backwards compatibility
     # Import key config components for backwards compatibility
-    from .config import (  # noqa: F401
-        ConfigManager,
-        ShortcutManager,
-        config_manager,
-        get_config,
-        set_config,
-    )
+    from .config import ShortcutManager  # noqa: F401
+    from .config import ConfigManager, config_manager, get_config, set_config
 
     # Import key history components for backwards compatibility
     from .history import HistoryManager, history_logger  # noqa: F401
-    from .resources import (  # noqa: F401
+    from .resources import ResourceTracker  # noqa: F401
+    from .resources import (
         ResourceMapper,
-        ResourceTracker,
         format_memory_size,
         format_walltime,
         parse_memory_size,

--- a/qxub/cancel_cli.py
+++ b/qxub/cancel_cli.py
@@ -7,6 +7,8 @@ matching with automatic database status updates.
 """
 
 import logging
+
+logger = logging.getLogger(__name__)
 import re
 import subprocess
 import time
@@ -633,7 +635,7 @@ def _wait_for_deletion(job_id: str, timeout: int, quiet: bool = False) -> bool:
 
         except Exception as e:
             if not quiet:
-                logging.debug(f"Error checking job status during deletion wait: {e}")
+                logger.debug(f"Error checking job status during deletion wait: {e}")
             break
 
     return False

--- a/qxub/config/handler.py
+++ b/qxub/config/handler.py
@@ -1,6 +1,8 @@
 """Configuration handling logic extracted from CLI for better separation of concerns."""
 
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 from pathlib import Path
 
@@ -156,7 +158,7 @@ def select_auto_queue(params):
         platform_names = loader.list_platforms()
 
         if not platform_names:
-            logging.warning(
+            logger.warning(
                 "No platforms available for auto queue selection, using 'normal'"
             )
             params["queue"] = "normal"
@@ -222,25 +224,25 @@ def select_auto_queue(params):
                             best_cost = cost
                             best_queue = selected_queue
             except Exception as e:
-                logging.debug(
+                logger.debug(
                     f"Failed to select queue from platform {platform.name}: {e}"
                 )
                 continue
 
         if best_queue:
             params["queue"] = best_queue
-            logging.info("Auto-selected queue: %s", best_queue)
+            logger.info("Auto-selected queue: %s", best_queue)
         else:
-            logging.warning("No suitable queue found for requirements, using 'normal'")
+            logger.warning("No suitable queue found for requirements, using 'normal'")
             params["queue"] = "normal"
 
     except ImportError:
-        logging.warning(
+        logger.warning(
             "Platform system not available for auto queue selection, using 'normal'"
         )
         params["queue"] = "normal"
     except Exception as e:
-        logging.warning("Auto queue selection failed: %s, using 'normal'", e)
+        logger.warning("Auto queue selection failed: %s, using 'normal'", e)
         params["queue"] = "normal"
 
     return params
@@ -297,7 +299,7 @@ def adjust_resources_for_queue(params):
 
                 if current_ncpus and current_ncpus > queue.limits.max_cpus:
                     # Default CPU count exceeds queue limit - adjust it gracefully
-                    logging.info(
+                    logger.info(
                         f"Automatically adjusting ncpus from {current_ncpus} to {queue.limits.max_cpus} "
                         f"for queue '{queue_name}' (default exceeds queue maximum)"
                     )
@@ -314,7 +316,7 @@ def adjust_resources_for_queue(params):
 
     except Exception as e:
         # Platform system not available or other error - don't adjust
-        logging.debug(f"Could not adjust resources for queue: {e}")
+        logger.debug(f"Could not adjust resources for queue: {e}")
 
     return params
 
@@ -333,6 +335,6 @@ def process_job_options(params, config_manager):
     # Build qsub options
     options = build_qsub_options(params)
 
-    logging.info("Options: %s", options)
+    logger.info("Options: %s", options)
 
     return params, options

--- a/qxub/core/scheduler.py
+++ b/qxub/core/scheduler.py
@@ -5,6 +5,8 @@ In simple cases, the need to create a jobscript can be eliminated entirely.
 """
 
 import logging
+
+logger = logging.getLogger(__name__)
 import shlex
 import subprocess
 import sys
@@ -234,7 +236,7 @@ def qsub(cmd, quiet=False):
         shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
     )
     if result.returncode != 0:
-        logging.debug("Job submission failed")
+        logger.debug("Job submission failed")
         # Map PBS validation errors to exit code 2 for consistency
         exit_code = 2 if result.returncode == 166 else result.returncode
         raise QsubError(
@@ -243,7 +245,7 @@ def qsub(cmd, quiet=False):
             stderr=result.stderr,
         )
     else:
-        logging.debug("Job submitted successfully")
+        logger.debug("Job submitted successfully")
         return result.stdout.rstrip("\n")
 
 
@@ -258,7 +260,7 @@ def qdel(job_id, quiet=False):
     Returns:
         bool: True if deletion was successful, False otherwise
     """
-    logging.debug("Deleting job %s", job_id)
+    logger.debug("Deleting job %s", job_id)
 
     try:
         # pylint: disable=W1510
@@ -268,17 +270,17 @@ def qdel(job_id, quiet=False):
         if result.returncode == 0:
             if not quiet:
                 click.echo(f"🗑️  Job {job_id} deleted successfully")
-            logging.info("Job %s deleted successfully", job_id)
+            logger.info("Job %s deleted successfully", job_id)
             return True
 
         if not quiet:
             click.echo(f"Failed to delete job {job_id}: {result.stderr.strip()}")
-        logging.warning("Failed to delete job %s: %s", job_id, result.stderr.strip())
+        logger.warning("Failed to delete job %s: %s", job_id, result.stderr.strip())
         return False
     except Exception as e:  # pylint: disable=broad-except
         if not quiet:
             click.echo(f"Error deleting job {job_id}: {e}")
-        logging.error("Error deleting job %s: %s", job_id, e)
+        logger.error("Error deleting job %s: %s", job_id, e)
         return False
 
 
@@ -348,9 +350,7 @@ def job_status_from_files(job_id, status_dir=None, log_dir=None):
                 else:
                     return "F", exit_code  # Failed with non-zero exit
         except (ValueError, IOError) as e:
-            logging.warning(
-                f"Could not read exit code from {final_exit_code_file}: {e}"
-            )
+            logger.warning(f"Could not read exit code from {final_exit_code_file}: {e}")
             return "C", None  # Assume completed if file exists but unreadable
 
     # Check for PBS job log with exit status (appears after job ends).
@@ -361,7 +361,7 @@ def job_status_from_files(job_id, status_dir=None, log_dir=None):
     #    PBS still writes the resource-usage block, so we can detect completion.
     exit_code = _check_pbs_job_log_for_exit(job_id, log_dir)
     if exit_code is not None:
-        logging.debug(f"Found PBS exit status {exit_code} for job {job_id} in log file")
+        logger.debug(f"Found PBS exit status {exit_code} for job {job_id} in log file")
         return ("C" if exit_code == 0 else "F"), exit_code
 
     # Check if job has started (and PBS log not yet written — still running)
@@ -441,11 +441,11 @@ def _check_pbs_job_log_for_exit(job_id, log_dir):
                     return int(exit_match.group(1))
 
             except (IOError, OSError) as e:
-                logging.debug(f"Could not read log file {log_file}: {e}")
+                logger.debug(f"Could not read log file {log_file}: {e}")
                 continue
 
     except Exception as e:
-        logging.debug(f"Error searching log files in {log_dir}: {e}")
+        logger.debug(f"Error searching log files in {log_dir}: {e}")
 
     return None
 
@@ -468,7 +468,7 @@ def get_job_resource_data(job_id):
         - timing: Dict of job timing information
         - metadata: Dict of job metadata (name, owner, etc.)
     """
-    logging.debug("Getting resource data for job %s", job_id)
+    logger.debug("Getting resource data for job %s", job_id)
 
     # Use standard qstat -fx format for full resource information
     qstat_result = subprocess.run(
@@ -480,12 +480,12 @@ def get_job_resource_data(job_id):
     )
 
     if qstat_result.returncode != 0:
-        logging.debug("qstat failed for job %s: %s", job_id, qstat_result.stderr)
+        logger.debug("qstat failed for job %s: %s", job_id, qstat_result.stderr)
         return None
 
     output = qstat_result.stdout.strip()
     if not output:
-        logging.debug("Empty qstat output for job %s", job_id)
+        logger.debug("Empty qstat output for job %s", job_id)
         return None
 
     return parse_qstat_fx_output(output)
@@ -529,7 +529,7 @@ def parse_qstat_fx_output(qstat_output):
             try:
                 data["exit_status"] = int(value)
             except ValueError:
-                logging.warning("Could not parse exit status: %s", value)
+                logger.warning("Could not parse exit status: %s", value)
 
         elif key.startswith("Resource_List."):
             # Requested resources
@@ -633,7 +633,7 @@ def _enhance_resource_data(data):
             efficiency["memory_requested_human"] = bytes_to_human(mem_requested_bytes)
             efficiency["memory_used_human"] = bytes_to_human(mem_used_bytes)
         except Exception as e:
-            logging.warning("Could not calculate memory efficiency: %s", e)
+            logger.warning("Could not calculate memory efficiency: %s", e)
 
     # Time efficiency
     if "walltime" in requested and "walltime" in used:
@@ -644,7 +644,7 @@ def _enhance_resource_data(data):
                 time_used_seconds, time_requested_seconds
             )
         except Exception as e:
-            logging.warning("Could not calculate time efficiency: %s", e)
+            logger.warning("Could not calculate time efficiency: %s", e)
 
     # CPU efficiency (from cpupercent if available)
     if "cpupercent" in used:
@@ -664,7 +664,7 @@ def _enhance_resource_data(data):
             efficiency["jobfs_requested_human"] = bytes_to_human(jobfs_requested_bytes)
             efficiency["jobfs_used_human"] = bytes_to_human(jobfs_used_bytes)
         except Exception as e:
-            logging.warning("Could not calculate jobfs efficiency: %s", e)
+            logger.warning("Could not calculate jobfs efficiency: %s", e)
 
     data["efficiency"] = efficiency
 
@@ -755,7 +755,7 @@ def collect_job_resources_after_completion(job_id, out_file):
         # Derive joblog path from out_file path
         joblog_path = str(out_file).replace(".out", ".log")
 
-        logging.debug("Waiting for PBS to finalize joblog for job %s", job_id)
+        logger.debug("Waiting for PBS to finalize joblog for job %s", job_id)
 
         # Wait 60 seconds for PBS to write final resource information to joblog
         time.sleep(60)
@@ -765,7 +765,7 @@ def collect_job_resources_after_completion(job_id, out_file):
         retry_delay = 60  # Wait 60 seconds between retries
 
         for attempt in range(max_retries):
-            logging.debug(
+            logger.debug(
                 "Attempting to collect resource usage from joblog for job %s "
                 "(attempt %d/%d)",
                 job_id,
@@ -785,35 +785,35 @@ def collect_job_resources_after_completion(job_id, out_file):
                         job_id, resource_data
                     )
                     if success:
-                        logging.debug(
+                        logger.debug(
                             f"Successfully updated resource data for job {job_id}"
                         )
                         return
 
-                    logging.debug(f"Failed to update resource data for job {job_id}")
+                    logger.debug(f"Failed to update resource data for job {job_id}")
                 else:
-                    logging.debug(
+                    logger.debug(
                         f"Could not parse resource data from joblog: {joblog_path}"
                     )
 
             except Exception as e:
-                logging.debug(
+                logger.debug(
                     f"Error collecting resources for job {job_id} (attempt {attempt + 1}): {e}"
                 )
 
             # If not the last attempt, wait before retrying
             if attempt < max_retries - 1:
-                logging.debug(
+                logger.debug(
                     f"Retrying resource collection in {retry_delay} seconds..."
                 )
                 time.sleep(retry_delay)
 
-        logging.debug(
+        logger.debug(
             f"Failed to collect resource data for job {job_id} after {max_retries} attempts"
         )
 
     except Exception as e:
-        logging.debug("Resource collection failed for job %s: %s", job_id, e)
+        logger.debug("Resource collection failed for job %s: %s", job_id, e)
 
 
 def start_background_resource_collection(
@@ -845,7 +845,7 @@ def start_background_resource_collection(
             with open(log_file, "a") as f:
                 f.write(f"[{timestamp}] {message}\n")
         except Exception as e:
-            logging.debug(f"Error writing to resource collection log: {e}")
+            logger.debug(f"Error writing to resource collection log: {e}")
 
     def collect_resources_background():
         """Actual resource collection logic."""
@@ -919,7 +919,7 @@ def start_background_resource_collection(
     try:
         pid = os.fork()
     except OSError as e:
-        logging.warning(f"Failed to fork for background resource collection: {e}")
+        logger.warning(f"Failed to fork for background resource collection: {e}")
         # Fall back to no collection rather than failing the whole job
         return None
 
@@ -1015,7 +1015,7 @@ def monitor_job_single_thread(
             # Check if job finished without running (rare but possible)
             if final_exit_code_file.exists():
                 spinner.clear()  # Clear spinner before showing message
-                logging.info("Job %s completed before starting", job_id)
+                logger.info("Job %s completed before starting", job_id)
                 exit_status = read_exit_status_from_file(final_exit_code_file)
 
                 # Completion message
@@ -1050,7 +1050,7 @@ def monitor_job_single_thread(
     if walltime_str:
         try:
             walltime_sec = max(0, time_to_seconds(walltime_str) + walltime_offset_sec)
-            logging.debug("Monitoring with walltime gate: %s s", walltime_sec)
+            logger.debug("Monitoring with walltime gate: %s s", walltime_sec)
         except Exception:
             pass  # Unknown format — fall back to immediate 60 s polling
 
@@ -1103,7 +1103,7 @@ def read_exit_status_from_file(exit_code_file):
             first_line = content.split("\n")[0]
             return int(first_line)
     except (OSError, IOError, ValueError) as e:
-        logging.warning(f"Could not read exit status from {exit_code_file}: {e}")
+        logger.warning(f"Could not read exit status from {exit_code_file}: {e}")
         return 1  # Default to failure
 
 
@@ -1254,7 +1254,7 @@ def stream_job_output_with_status_files(
                                     print(line.rstrip(), file=sys.stderr, flush=True)
                         except (OSError, IOError):
                             pass
-                    logging.debug(
+                    logger.debug(
                         "Job %s terminated by PBS (exit %s), detected via job log",
                         job_id,
                         pbs_exit,

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -522,7 +522,7 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
         if value is not None:
             import logging
 
-            logging.warning(
+            logger.warning(
                 f"Config key '{key}' at root level is deprecated. "
                 f"Please move to 'defaults.{key}' in your config file."
             )

--- a/qxub/execution/context.py
+++ b/qxub/execution/context.py
@@ -8,6 +8,8 @@ and execute_default functions.
 
 import base64
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 from pathlib import Path
 from typing import List, Optional, Union
@@ -129,22 +131,22 @@ class ExecutionContext:
         """Log debug information for this execution context."""
         # Log context parameters
         for key, value in ctx_obj.items():
-            logging.debug("Context: %s = %s", key, value)
+            logger.debug("Context: %s = %s", key, value)
 
         # Log context-specific information
         if self.context_type == "conda":
-            logging.debug("Conda environment: %s", self.context_value)
+            logger.debug("Conda environment: %s", self.context_value)
         elif self.context_type == "module":
-            logging.debug("Environment modules: %s", self.context_value)
+            logger.debug("Environment modules: %s", self.context_value)
         elif self.context_type == "singularity":
-            logging.debug("Singularity container: %s", self.context_value)
+            logger.debug("Singularity container: %s", self.context_value)
         else:
-            logging.debug("Default execution context")
+            logger.debug("Default execution context")
 
-        logging.debug("Jobscript template: %s", template)
-        logging.debug("Command: %s", command)
-        logging.debug("Pre-commands: %s", pre)
-        logging.debug("Post-commands: %s", post)
+        logger.debug("Jobscript template: %s", template)
+        logger.debug("Command: %s", command)
+        logger.debug("Pre-commands: %s", pre)
+        logger.debug("Post-commands: %s", post)
 
 
 def execute_unified(
@@ -186,7 +188,7 @@ def execute_unified(
 
     # Build final submission command
     submission_command = f'qsub -v {submission_vars} {ctx_obj["options"]} {template}'
-    logging.info("Submission command: %s", submission_command)
+    logger.info("Submission command: %s", submission_command)
 
     # Progress message: Job command constructed (skip for terse mode)
     if not ctx_obj["quiet"] and not ctx_obj.get("terse", False):
@@ -211,7 +213,7 @@ def execute_unified(
                 tags=ctx_obj.get("tags") or [],
             )
         except Exception as e:
-            logging.debug("Failed to log execution history: %s", e)
+            logger.debug("Failed to log execution history: %s", e)
         return
 
     # ------------------------------------------------------------------
@@ -241,7 +243,7 @@ def execute_unified(
             cpus_requested=_parse_cpus_from_resources(ctx_obj.get("resources", [])),
         )
     except Exception as e:
-        logging.debug("Failed to create queue entry: %s", e)
+        logger.debug("Failed to create queue entry: %s", e)
 
     # ------------------------------------------------------------------
     # Submit job to PBS
@@ -281,7 +283,7 @@ def execute_unified(
                 joblog_path=ctx_obj.get("joblog"),
             )
         except Exception as e:
-            logging.debug("Failed to update queue entry: %s", e)
+            logger.debug("Failed to update queue entry: %s", e)
 
     # Log job submission for status and resource tracking (do this before terse return)
     try:
@@ -294,7 +296,7 @@ def execute_unified(
             cpus_requested=_parse_cpus_from_resources(ctx_obj.get("resources", [])),
         )
     except Exception as e:
-        logging.debug("Failed to log job submission: %s", e)
+        logger.debug("Failed to log job submission: %s", e)
 
     # Log execution to history system (must happen before terse mode early return)
     try:
@@ -312,13 +314,13 @@ def execute_unified(
             tags=ctx_obj.get("tags") or [],
         )
     except Exception as e:
-        logging.debug("Failed to log execution history: %s", e)
+        logger.debug("Failed to log execution history: %s", e)
 
     # Handle terse mode - emit real PBS job ID and return immediately (for pipeline use)
     # Virtual IDs will be emitted here once Phase 3 introduces pending-dispatch.
     if ctx_obj.get("terse", False):
         click.echo(job_id)
-        logging.info(
+        logger.info(
             "Terse mode: emitted job ID %s and returning immediately",
             job_id,
         )

--- a/qxub/execution/core.py
+++ b/qxub/execution/core.py
@@ -7,6 +7,8 @@ that was previously duplicated across multiple execution functions.
 
 import base64
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import re
 import sys
@@ -86,7 +88,7 @@ def _apply_variable_expansion(cmd_str: str) -> str:
         if value is not None:
             return value
         else:
-            logging.warning(
+            logger.warning(
                 f"Submission variable ${{{var_name}}} not found in environment"
             )
             return match.group(0)  # Keep original ${var}
@@ -262,12 +264,12 @@ def submit_and_monitor_job(
 
     # Log parameters and context
     for key, value in ctx_obj.items():
-        logging.debug("Context: %s = %s", key, value)
-    logging.debug("Template: %s", template)
-    logging.debug("Command: %s", command)
-    logging.debug("Context vars: %s", context_vars)
-    logging.debug("Pre-commands: %s", pre)
-    logging.debug("Post-commands: %s", post)
+        logger.debug("Context: %s = %s", key, value)
+    logger.debug("Template: %s", template)
+    logger.debug("Command: %s", command)
+    logger.debug("Context vars: %s", context_vars)
+    logger.debug("Pre-commands: %s", pre)
+    logger.debug("Post-commands: %s", post)
 
     # Build submission variables
     submission_vars = build_submission_variables(
@@ -283,7 +285,7 @@ def submit_and_monitor_job(
 
     # Construct qsub command
     submission_command = f'qsub -v {submission_vars} {ctx_obj["options"]} {template}'
-    logging.info("Submission command: %s", submission_command)
+    logger.info("Submission command: %s", submission_command)
 
     # Progress message: Job command constructed (skip for terse mode)
     if not ctx_obj["quiet"] and not ctx_obj.get("terse", False):
@@ -319,7 +321,7 @@ def submit_and_monitor_job(
         try:
             history_manager.log_execution(ctx, success=True)
         except Exception as e:
-            logging.debug("Failed to log execution history: %s", e)
+            logger.debug("Failed to log execution history: %s", e)
         return
 
     # Submit job
@@ -328,7 +330,7 @@ def submit_and_monitor_job(
     # Handle terse mode - emit only job ID and return immediately
     if ctx_obj.get("terse", False):
         click.echo(job_id)
-        logging.info("Terse mode: emitted job ID %s and exiting", job_id)
+        logger.info("Terse mode: emitted job ID %s and exiting", job_id)
         return
 
     # Display job ID to user (unless in quiet mode)
@@ -340,11 +342,11 @@ def submit_and_monitor_job(
     try:
         history_manager.log_execution(ctx, success=True, job_id=job_id)
     except Exception as e:
-        logging.debug("Failed to log execution history: %s", e)
+        logger.debug("Failed to log execution history: %s", e)
 
     # Exit if in quiet mode
     if ctx_obj["quiet"]:
-        logging.info("Exiting in quiet mode")
+        logger.info("Exiting in quiet mode")
         return
 
     # Prepare output files

--- a/qxub/execution/submit.py
+++ b/qxub/execution/submit.py
@@ -23,6 +23,8 @@ Usage::
 
 import base64
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
@@ -270,7 +272,7 @@ def submit_job(
     # Build qsub command
     # ------------------------------------------------------------------
     submission_command = f"qsub -v {submission_vars} {qsub_options} {template}"
-    logging.info("Programmatic submission command: %s", submission_command)
+    logger.info("Programmatic submission command: %s", submission_command)
 
     # ------------------------------------------------------------------
     # Pre-qsub: create queue entry (status = initiated)
@@ -300,7 +302,7 @@ def submit_job(
             cpus_requested=ncpus if ncpus else None,
         )
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("Failed to create queue entry: %s", exc)
+        logger.debug("Failed to create queue entry: %s", exc)
 
     # ------------------------------------------------------------------
     # Submit to PBS (raises QsubError on failure — no sys.exit)
@@ -327,7 +329,7 @@ def submit_job(
                 joblog_path=processed_params.get("joblog"),
             )
         except Exception as exc:  # pylint: disable=broad-except
-            logging.debug("Failed to update queue entry: %s", exc)
+            logger.debug("Failed to update queue entry: %s", exc)
 
     # ------------------------------------------------------------------
     # Resource tracker + history logging
@@ -343,7 +345,7 @@ def submit_job(
             cpus_requested=ncpus_req if ncpus_req else None,
         )
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("Failed to log job submission: %s", exc)
+        logger.debug("Failed to log job submission: %s", exc)
 
     # ------------------------------------------------------------------
     # Return structured result

--- a/qxub/execution_context.py
+++ b/qxub/execution_context.py
@@ -8,6 +8,8 @@ and execute_default functions.
 
 import base64
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 from pathlib import Path
 from typing import List, Union
@@ -110,22 +112,22 @@ class ExecutionContext:
         """Log debug information for this execution context."""
         # Log context parameters
         for key, value in ctx_obj.items():
-            logging.debug("Context: %s = %s", key, value)
+            logger.debug("Context: %s = %s", key, value)
 
         # Log context-specific information
         if self.context_type == "conda":
-            logging.debug("Conda environment: %s", self.context_value)
+            logger.debug("Conda environment: %s", self.context_value)
         elif self.context_type == "module":
-            logging.debug("Environment modules: %s", self.context_value)
+            logger.debug("Environment modules: %s", self.context_value)
         elif self.context_type == "singularity":
-            logging.debug("Singularity container: %s", self.context_value)
+            logger.debug("Singularity container: %s", self.context_value)
         else:
-            logging.debug("Default execution context")
+            logger.debug("Default execution context")
 
-        logging.debug("Jobscript template: %s", template)
-        logging.debug("Command: %s", command)
-        logging.debug("Pre-commands: %s", pre)
-        logging.debug("Post-commands: %s", post)
+        logger.debug("Jobscript template: %s", template)
+        logger.debug("Command: %s", command)
+        logger.debug("Pre-commands: %s", pre)
+        logger.debug("Post-commands: %s", post)
 
 
 def execute_unified(
@@ -168,7 +170,7 @@ def execute_unified(
 
     # Build final submission command
     submission_command = f'qsub -v {submission_vars} {ctx_obj["options"]} {template}'
-    logging.info("Submission command: %s", submission_command)
+    logger.info("Submission command: %s", submission_command)
 
     # Progress message: Job command constructed (skip for terse mode)
     if not ctx_obj["quiet"] and not ctx_obj.get("terse", False):
@@ -195,7 +197,7 @@ def execute_unified(
             print("DEBUG: Execution logged successfully")  # DEBUG
         except Exception as e:
             print(f"DEBUG: Failed to log execution history: {e}")  # DEBUG
-            logging.debug("Failed to log execution history: %s", e)
+            logger.debug("Failed to log execution history: %s", e)
         return
 
     # Submit job
@@ -206,12 +208,12 @@ def execute_unified(
         cmd_str = " ".join(command)
         resource_tracker.log_job_submitted(job_id=job_id, command=cmd_str)
     except Exception as e:
-        logging.debug("Failed to log job submission: %s", e)
+        logger.debug("Failed to log job submission: %s", e)
 
     # Handle terse mode - emit job ID but continue monitoring like quiet mode
     if ctx_obj.get("terse", False):
         click.echo(job_id)
-        logging.info(
+        logger.info(
             "Terse mode: emitted job ID %s and continuing with silent monitoring",
             job_id,
         )
@@ -235,7 +237,7 @@ def execute_unified(
             ctx, success=True, job_id=job_id, file_paths=file_paths
         )
     except Exception as e:
-        logging.debug("Failed to log execution history: %s", e)
+        logger.debug("Failed to log execution history: %s", e)
 
     # All modes now continue to monitoring (removed the quiet mode early return)
 

--- a/qxub/history/base.py
+++ b/qxub/history/base.py
@@ -177,7 +177,7 @@ class CommandHistoryLogger:
             # Just log the error and continue
             import logging
 
-            logging.debug("Failed to log command to history: %s", str(e))
+            logger.debug("Failed to log command to history: %s", str(e))
 
     def get_recent_commands(self, limit: int = 10) -> List[Dict[str, Any]]:
         """Get recent commands from history."""

--- a/qxub/history/manager.py
+++ b/qxub/history/manager.py
@@ -300,7 +300,7 @@ class HistoryManager:
             # Don't let history logging break the main command
             import logging
 
-            logging.debug("Failed to log execution to history: %s", str(e))
+            logger.debug("Failed to log execution to history: %s", str(e))
             return str(int(time.time() * 1000000))
 
     def update_execution_with_resources(
@@ -342,7 +342,7 @@ class HistoryManager:
         except Exception as e:
             import logging
 
-            logging.debug("Failed to update execution with resources: %s", str(e))
+            logger.debug("Failed to update execution with resources: %s", str(e))
             return False
 
     def get_recipes(self) -> Dict[str, Any]:

--- a/qxub/monitor_cli.py
+++ b/qxub/monitor_cli.py
@@ -7,6 +7,8 @@ and blocks until all jobs are complete.
 """
 
 import logging
+
+logger = logging.getLogger(__name__)
 import signal
 import sys
 import threading
@@ -83,7 +85,7 @@ class MultiJobMonitor:
 
     def _signal_handler(self, signum, frame):
         """Handle SIGINT (Ctrl+C) gracefully."""
-        logging.info("Interrupt received, shutting down monitor...")
+        logger.info("Interrupt received, shutting down monitor...")
         self.shutdown_requested.set()
 
     def _strip_suffix(self, job_id: str) -> str:
@@ -121,7 +123,7 @@ class MultiJobMonitor:
             return status, job_name, exit_code
 
         except Exception as e:
-            logging.debug(f"Failed to check status for job {job_id}: {e}")
+            logger.debug(f"Failed to check status for job {job_id}: {e}")
             return "Q", None, None  # Assume queued if we can't check
 
     def _get_status_emoji(self, status: str, exit_code: Optional[int] = None) -> str:
@@ -253,7 +255,7 @@ class MultiJobMonitor:
             click.echo("No job IDs to monitor.", err=True)
             return 1
 
-        logging.info(f"Monitoring {len(self.job_ids)} jobs...")
+        logger.info(f"Monitoring {len(self.job_ids)} jobs...")
 
         # Initial status check
         self._update_all_statuses()

--- a/qxub/queue/db.py
+++ b/qxub/queue/db.py
@@ -13,6 +13,8 @@ concurrent access from multiple workflow nodes.
 import base64
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import sqlite3
 import uuid
@@ -262,13 +264,13 @@ def _migrate_queue_schema(conn) -> None:
         for col_name, col_type in _QUEUE_NEW_COLUMNS:
             if col_name not in existing:
                 conn.execute(f"ALTER TABLE queue ADD COLUMN {col_name} {col_type}")
-                logging.debug("queue: added column %s %s", col_name, col_type)
+                logger.debug("queue: added column %s %s", col_name, col_type)
 
         # Backfill: change old default status 'dispatched' to keep working
         # (new default is 'initiated' but existing rows already have a status)
         conn.commit()
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("Queue schema migration failed (may be normal): %s", exc)
+        logger.debug("Queue schema migration failed (may be normal): %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +382,7 @@ def create_queue_entry(
                     (pbs_job_id, entry_id, user, now, json.dumps(tags or [])),
                 )
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("Failed to create queue entry: %s", exc)
+        logger.debug("Failed to create queue entry: %s", exc)
 
     return entry_id
 
@@ -399,7 +401,7 @@ def get_queue_entry(pbs_job_id: str, db_path: Optional[Path] = None) -> Optional
             ).fetchone()
             return dict(row) if row else None
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("get_queue_entry failed for %s: %s", pbs_job_id, exc)
+        logger.debug("get_queue_entry failed for %s: %s", pbs_job_id, exc)
         return None
 
 
@@ -470,7 +472,7 @@ def update_queue_entry(
 
             return result.rowcount > 0
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("update_queue_entry failed for %s: %s", virtual_id, exc)
+        logger.debug("update_queue_entry failed for %s: %s", virtual_id, exc)
         return False
 
 
@@ -507,7 +509,7 @@ def get_entries_bulk(
             ).fetchall()
             return {row["entry_id"]: dict(row) for row in rows}
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("get_entries_bulk failed: %s", exc)
+        logger.debug("get_entries_bulk failed: %s", exc)
         return {}
 
 
@@ -534,7 +536,7 @@ def mark_running(pbs_job_id: str, db_path: Optional[Path] = None) -> None:
                 (now, now, pbs_job_id),
             )
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("mark_running failed for %s: %s", pbs_job_id, exc)
+        logger.debug("mark_running failed for %s: %s", pbs_job_id, exc)
 
 
 def mark_complete(
@@ -568,7 +570,7 @@ def mark_complete(
                 (status, now, exit_code, now, pbs_job_id),
             )
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("mark_complete failed for %s: %s", pbs_job_id, exc)
+        logger.debug("mark_complete failed for %s: %s", pbs_job_id, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -603,7 +605,7 @@ def resolve_virtual_id(
             ).fetchone()
             return dict(row) if row else None
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("resolve_virtual_id failed for %s: %s", virtual_id, exc)
+        logger.debug("resolve_virtual_id failed for %s: %s", virtual_id, exc)
         return None
 
 
@@ -625,5 +627,5 @@ def get_project_job_status(
             ).fetchone()
             return dict(row) if row else None
     except Exception as exc:  # pylint: disable=broad-except
-        logging.debug("get_project_job_status failed for %s: %s", pbs_job_id, exc)
+        logger.debug("get_project_job_status failed for %s: %s", pbs_job_id, exc)
         return None

--- a/qxub/resources/tracker.py
+++ b/qxub/resources/tracker.py
@@ -7,6 +7,8 @@ Uses SQLite for simple querying and analysis.
 
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import re
 import sqlite3
@@ -64,9 +66,9 @@ def _resolve_tracker_db_path() -> Path:
 
         try:
             shutil.copy2(str(old_path), str(resolved))
-            logging.debug("Migrated resources.db → %s", resolved)
+            logger.debug("Migrated resources.db → %s", resolved)
         except Exception as exc:  # pylint: disable=broad-except
-            logging.debug("Could not migrate resources.db: %s", exc)
+            logger.debug("Could not migrate resources.db: %s", exc)
 
     return resolved
 
@@ -180,9 +182,7 @@ class ResourceTracker:
             columns = [row[1] for row in cursor.fetchall()]
 
             if "status" not in columns:
-                logging.debug(
-                    "Migrating database schema to add status tracking columns"
-                )
+                logger.debug("Migrating database schema to add status tracking columns")
 
                 # Add new columns
                 conn.execute(
@@ -207,29 +207,29 @@ class ResourceTracker:
                 )
 
                 conn.commit()
-                logging.debug("Database schema migration completed")
+                logger.debug("Database schema migration completed")
 
             if "tags" not in columns:
-                logging.debug("Migrating database schema to add tags column")
+                logger.debug("Migrating database schema to add tags column")
                 conn.execute(
                     "ALTER TABLE job_resources ADD COLUMN tags TEXT DEFAULT '[]'"
                 )
                 conn.commit()
-                logging.debug("Tags column migration completed")
+                logger.debug("Tags column migration completed")
 
             if "username" not in columns:
-                logging.debug("Migrating database schema to add username column")
+                logger.debug("Migrating database schema to add username column")
                 conn.execute("ALTER TABLE job_resources ADD COLUMN username TEXT")
                 conn.commit()
-                logging.debug("Username column migration completed")
+                logger.debug("Username column migration completed")
 
             if "joblog_path" not in columns:
-                logging.debug("Migrating database schema to add joblog_path column")
+                logger.debug("Migrating database schema to add joblog_path column")
                 conn.execute("ALTER TABLE job_resources ADD COLUMN joblog_path TEXT")
                 conn.commit()
-                logging.debug("joblog_path column migration completed")
+                logger.debug("joblog_path column migration completed")
         except Exception as e:
-            logging.debug("Database migration failed (may be normal): %s", e)
+            logger.debug("Database migration failed (may be normal): %s", e)
 
     def log_job_resources(
         self, job_id: str, resource_data: Dict[str, Any], command: Optional[str] = None
@@ -299,11 +299,11 @@ class ResourceTracker:
                 )
                 conn.commit()
 
-            logging.debug("Logged resource data for job %s", job_id)
+            logger.debug("Logged resource data for job %s", job_id)
             return True
 
         except Exception as e:
-            logging.debug("Failed to log resource data for job %s: %s", job_id, e)
+            logger.debug("Failed to log resource data for job %s: %s", job_id, e)
             return False
 
     def update_job_resources(self, job_id: str, resource_data: Dict[str, Any]) -> bool:
@@ -407,7 +407,7 @@ class ResourceTracker:
                     values.append(value)
 
             if not set_clauses:
-                logging.debug("No valid resource data to update for job %s", job_id)
+                logger.debug("No valid resource data to update for job %s", job_id)
                 return False
 
             values.append(job_id)  # For WHERE clause
@@ -418,7 +418,7 @@ class ResourceTracker:
                 result = conn.execute(sql, values)
 
                 if result.rowcount == 0:
-                    logging.debug(
+                    logger.debug(
                         "No existing record found to update for job %s", job_id
                     )
 
@@ -431,11 +431,11 @@ class ResourceTracker:
 
                 conn.commit()
 
-            logging.debug("Updated resource data for job %s", job_id)
+            logger.debug("Updated resource data for job %s", job_id)
             return True
 
         except Exception as e:
-            logging.debug("Failed to update resource data for job %s: %s", job_id, e)
+            logger.debug("Failed to update resource data for job %s: %s", job_id, e)
             return False
 
     def _clean_command(self, command: Optional[str]) -> Optional[str]:
@@ -705,7 +705,7 @@ class ResourceTracker:
 
                 conn.commit()
 
-            logging.debug(
+            logger.debug(
                 "Logged job submission for %s (user: %s, tags: %s)",
                 job_id,
                 username,
@@ -713,7 +713,7 @@ class ResourceTracker:
             )
             return True
         except Exception as e:
-            logging.debug("Failed to log job submission for %s: %s", job_id, e)
+            logger.debug("Failed to log job submission for %s: %s", job_id, e)
             return False
 
     def update_job_status(self, job_id: str, status: str) -> bool:
@@ -761,10 +761,10 @@ class ResourceTracker:
 
                 conn.commit()
 
-            logging.debug("Updated job %s status to %s", job_id, status)
+            logger.debug("Updated job %s status to %s", job_id, status)
             return True
         except Exception as e:
-            logging.debug("Failed to update job status for %s: %s", job_id, e)
+            logger.debug("Failed to update job status for %s: %s", job_id, e)
             return False
 
     def update_job_exit_code(self, job_id: str, exit_code: int) -> bool:
@@ -776,10 +776,10 @@ class ResourceTracker:
                     (exit_code, job_id),
                 )
                 conn.commit()
-            logging.debug("Updated job %s exit_code to %s", job_id, exit_code)
+            logger.debug("Updated job %s exit_code to %s", job_id, exit_code)
             return True
         except Exception as e:
-            logging.debug("Failed to update exit code for %s: %s", job_id, e)
+            logger.debug("Failed to update exit code for %s: %s", job_id, e)
             return False
 
     def finalize_job(self, job_id: str, exit_code: int, joblog_path: str) -> bool:
@@ -816,12 +816,12 @@ class ResourceTracker:
                 )
 
                 conn.commit()
-            logging.debug(
+            logger.debug(
                 "Finalized job %s (exit=%s, status=%s)", job_id, exit_code, status
             )
             return True
         except Exception as exc:  # pylint: disable=broad-except
-            logging.debug("Failed to finalize job %s: %s", job_id, exc)
+            logger.debug("Failed to finalize job %s: %s", job_id, exc)
             return False
 
     # ------------------------------------------------------------------
@@ -918,7 +918,7 @@ class ResourceTracker:
                 ).fetchall()
             missing_ids = {row[0] for row in missing}
         except Exception as exc:  # pylint: disable=broad-except
-            logging.debug("backfill phase-1 query failed: %s", exc)
+            logger.debug("backfill phase-1 query failed: %s", exc)
             missing_ids = set()
 
         if missing_ids:
@@ -937,12 +937,12 @@ class ResourceTracker:
                                 [(path, jid) for jid, path in matched.items()],
                             )
                             conn.commit()
-                        logging.debug(
+                        logger.debug(
                             "Discovered joblog paths for %d historical jobs",
                             len(matched),
                         )
                     except Exception as exc:  # pylint: disable=broad-except
-                        logging.debug("backfill path-update failed: %s", exc)
+                        logger.debug("backfill path-update failed: %s", exc)
 
         # ---- Phase 2: parse joblogs and fill resource columns ---------------
         try:
@@ -960,7 +960,7 @@ class ResourceTracker:
                     (limit,),
                 ).fetchall()
         except Exception as exc:  # pylint: disable=broad-except
-            logging.debug("backfill phase-2 query failed: %s", exc)
+            logger.debug("backfill phase-2 query failed: %s", exc)
             return 0
 
         filled = 0
@@ -971,9 +971,9 @@ class ResourceTracker:
                     ok = self.update_job_resources(row["job_id"], data)
                     if ok:
                         filled += 1
-                        logging.debug("Backfilled resources for %s", row["job_id"])
+                        logger.debug("Backfilled resources for %s", row["job_id"])
             except Exception as exc:  # pylint: disable=broad-except
-                logging.debug("Backfill failed for %s: %s", row["job_id"], exc)
+                logger.debug("Backfill failed for %s: %s", row["job_id"], exc)
         return filled
 
     def get_job_status(self, job_id: str) -> Optional[Dict[str, Any]]:
@@ -1020,7 +1020,7 @@ class ResourceTracker:
                     return dict(row) if row else None
             except Exception as e:  # pylint: disable=broad-except
                 last_exc = e
-                logging.debug(
+                logger.debug(
                     "get_job_status attempt %d failed for %s: %s",
                     attempt + 1,
                     job_id,
@@ -1066,7 +1066,7 @@ class ResourceTracker:
                 cursor = conn.execute(query, params)
                 return [dict(row) for row in cursor.fetchall()]
         except Exception as e:
-            logging.debug("Failed to get jobs by status: %s", e)
+            logger.debug("Failed to get jobs by status: %s", e)
             return []
 
     def get_status_summary(self) -> Dict[str, int]:
@@ -1083,7 +1083,7 @@ class ResourceTracker:
                 )
                 return {row[0]: row[1] for row in cursor.fetchall()}
         except Exception as e:
-            logging.debug("Failed to get status summary: %s", e)
+            logger.debug("Failed to get status summary: %s", e)
             return {}
 
     def cleanup_old_jobs(self, days_old: int = 30) -> int:
@@ -1102,10 +1102,10 @@ class ResourceTracker:
                 deleted_count = cursor.rowcount
                 conn.commit()
 
-            logging.debug("Cleaned up %d old job records", deleted_count)
+            logger.debug("Cleaned up %d old job records", deleted_count)
             return deleted_count
         except Exception as e:
-            logging.debug("Failed to cleanup old jobs: %s", e)
+            logger.debug("Failed to cleanup old jobs: %s", e)
             return 0
 
     def export_csv(self, output_path: Path, limit: Optional[int] = None):

--- a/qxub/resources_cli.py
+++ b/qxub/resources_cli.py
@@ -73,9 +73,11 @@ def list(limit, tag, user, since, before, queue_name, status, output_csv):
     try:
         filled = resource_tracker.backfill_resources()
         if filled:
-            import logging as _logging
+            import logging
 
-            _logging.debug("Backfilled resources for %d job(s)", filled)
+            logging.getLogger(__name__).debug(
+                "Backfilled resources for %d job(s)", filled
+            )
     except Exception:  # pylint: disable=broad-except
         pass
 

--- a/qxub/status_cli.py
+++ b/qxub/status_cli.py
@@ -6,6 +6,8 @@ Provides the `qxub status` command for viewing job status without qstat polling.
 
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import sys
 from datetime import datetime, timedelta
 
@@ -282,7 +284,7 @@ def check(job_id, output_format, snakemake):
         # Transient DB failure — for snakemake mode, report "running" so the
         # workflow engine retries instead of aborting.  For other formats,
         # surface the error but still exit 0 to avoid false-positive failures.
-        logging.debug("Database error during status check: %s", exc)
+        logger.debug("Database error during status check: %s", exc)
         if output_format == "snakemake":
             print("running")
             return

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="qxub",
-    version="3.5.0.dev2",
+    version="3.5.0.dev3",
     author="John Reeves",
     author_email="j.reeves@garvan.org.au",
     description="Simplified job submission to HPC",


### PR DESCRIPTION
## Summary

Replaces all 143 root-logger calls with named loggers across 15 modules — fixes duplicate log output when qxub is used as a library.

## Problem

`logging.info(...)` / `logging.debug(...)` etc. (root logger calls) trigger Python's `basicConfig()` auto-setup on first use, adding a `StreamHandler(sys.stderr)` to the root logger. When qxub is imported by another application (e.g. Snakemake), this causes every log message from every logger in the process to appear twice — once from the application's handler and once from the auto-added root handler.

## Fix

### Named loggers (all 15 affected modules)
```python
# Before:
logging.info("message")

# After:
logger = logging.getLogger(__name__)  # module-level
logger.info("message")
```

### NullHandler (`qxub/__init__.py`)
Added `logging.getLogger("qxub").addHandler(logging.NullHandler())` — standard Python library best practice that prevents "No handler found" warnings and avoids triggering `basicConfig()`.

### Files changed
- `qxub/__init__.py` — NullHandler + version bump to 3.5.0.dev3
- `qxub/cancel_cli.py`
- `qxub/config/handler.py`
- `qxub/core/scheduler.py`
- `qxub/exec_cli.py`
- `qxub/execution/context.py`
- `qxub/execution_context.py`
- `qxub/execution/core.py`
- `qxub/execution/submit.py`
- `qxub/history/base.py`
- `qxub/history/manager.py`
- `qxub/monitor_cli.py`
- `qxub/queue/db.py`
- `qxub/resources_cli.py` (also fixed `_logging` alias)
- `qxub/resources/tracker.py`
- `qxub/status_cli.py`
- `setup.py` — version 3.5.0.dev3

Closes #70