### PR TITLE
fix: replace WAL journal mode with DELETE and defer ResourceTracker singleton

### DIFF
--- a/qxub/__init__.py
+++ b/qxub/__init__.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "3.5.0.dev4"
+__version__ = "3.5.0.dev5"
 
 # Library-standard NullHandler: prevents "No handler found" warnings and
 # avoids triggering basicConfig() when qxub is used as a library.

--- a/qxub/queue/db.py
+++ b/qxub/queue/db.py
@@ -77,7 +77,7 @@ def get_connection(db_path: Optional[Path] = None):
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
     conn = sqlite3.connect(str(db_path), timeout=5.0)
-    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA journal_mode=DELETE")
     conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA mmap_size=0")
     conn.row_factory = sqlite3.Row

--- a/qxub/resources/tracker.py
+++ b/qxub/resources/tracker.py
@@ -113,9 +113,9 @@ class ResourceTracker:
     def _init_database(self):
         """Initialize SQLite database with resource tracking table."""
         with self._connect() as conn:
-            # WAL mode allows concurrent readers even during writes,
-            # eliminating most lock-contention issues.
-            conn.execute("PRAGMA journal_mode=WAL")
+            # DELETE mode avoids -shm sidecar which is always mmap'd.
+            # WAL's -shm causes SIGBUS on shared filesystems (Lustre/GPFS).
+            conn.execute("PRAGMA journal_mode=DELETE")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS job_resources (
@@ -1129,5 +1129,23 @@ class ResourceTracker:
                     writer.writerow(dict(zip(columns, row)))
 
 
-# Global instance
-resource_tracker = ResourceTracker()
+# Lazy global instance — avoids running _init_database() at import time,
+# which would fail fatally if the DB is corrupted or on a broken filesystem.
+_resource_tracker = None
+
+
+def _get_resource_tracker():
+    global _resource_tracker  # noqa: PLW0603
+    if _resource_tracker is None:
+        _resource_tracker = ResourceTracker()
+    return _resource_tracker
+
+
+class _LazyResourceTracker:
+    """Proxy that defers ResourceTracker construction until first use."""
+
+    def __getattr__(self, name):
+        return getattr(_get_resource_tracker(), name)
+
+
+resource_tracker = _LazyResourceTracker()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="qxub",
-    version="3.5.0.dev4",
+    version="3.5.0.dev5",
     author="John Reeves",
     author_email="j.reeves@garvan.org.au",
     description="Simplified job submission to HPC",


### PR DESCRIPTION
## Summary

Fixes SIGBUS crashes caused by WAL journal mode's `-shm` sidecar file being memory-mapped on shared filesystems (Lustre/GPFS). Also defers the `ResourceTracker` singleton to prevent import-time DB failures from cascading.

## Problem

`journal_mode=WAL` creates `-wal` and `-shm` sidecar files. SQLite **always** memory-maps the `-shm` file — there is no pragma to disable this. On shared/parallel filesystems, concurrent writers corrupt the `-shm` mmap region, causing SIGBUS.

This made the `PRAGMA mmap_size=0` fix from PR #71 incomplete: the main DB file was safe, but WAL re-introduced the same vulnerability via `-shm`.

Additionally, `ResourceTracker` was a module-level singleton that ran `_init_database()` at **import time**. If the DB was corrupted, this caused cascading `ImportError` for unrelated names like `QsubError`.

## Fix

### WAL → DELETE
- `qxub/queue/db.py` — `PRAGMA journal_mode=DELETE`
- `qxub/resources/tracker.py` — `PRAGMA journal_mode=DELETE`

DELETE mode uses only a `-journal` rollback file with normal I/O — no mmap, no SIGBUS. Performance difference is negligible for qxub's access patterns.

### Lazy ResourceTracker singleton
- Replace `resource_tracker = ResourceTracker()` (runs at import time) with `_LazyResourceTracker` proxy that defers construction until first attribute access
- DB connection only happens when actually needed, not at import time

## Version

Bumps to `3.5.0.dev5`.

Closes #75