### PR TITLE
feat: add --var and --vars options to set environment variables in jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ qxub exec --shortcut python -- script.py
 | `--runtime` / `--time` | Walltime limit (workflow-friendly, default: configured) | `--runtime 2h30m` or `--time 1h` |
 | `--disk` / `--jobfs` | Local disk requirement (workflow-friendly, default: configured) | `--disk 100GB` or `--jobfs 50GB` |
 | `--volumes` / `--storage` | NCI storage volumes to mount (default: configured) | `--volumes gdata/a56` or `--storage gdata/a56+scratch/a56` |
+| `--var` | Set environment variable in job (repeatable) | `--var FOO=bar --var BAZ=qux` |
+| `--vars` | Set multiple env vars (comma-separated) | `--vars "FOO=bar,BAZ=qux"` |
 | `--queue` | PBS queue (use `auto` for cost optimization!) | `--queue auto` |
 | `--name` | Job name | `--name myjob` |
 | `--project` | PBS project | `--project a56` |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -131,6 +131,29 @@ qxub config list
 qxub config reset
 ```
 
+## Environment Variables
+
+Pass custom environment variables to your job using `--var` or `--vars`:
+
+```bash
+# Single variable
+qxub exec --var "MY_VAR=value" --env base -- echo '$MY_VAR'
+
+# Multiple variables with --var (repeatable)
+qxub exec --var "FOO=bar" --var "BAZ=qux" --default -- 'echo $FOO $BAZ'
+
+# Comma-separated list with --vars
+qxub exec --vars "FOO=bar,BAZ=qux" --env base -- python script.py
+
+# Both options together
+qxub exec --var "DEBUG=1" --vars "INPUT=/data,OUTPUT=/results" --env pytorch -- python train.py
+
+# Variables with spaces (quoted values)
+qxub exec --var "GREETING=hello world" --env myenv -- 'echo $GREETING'
+```
+
+Variables are exported before your command runs, making them available to your script and any subprocesses.
+
 ## Basic Execution
 
 ```bash

--- a/qxub/cli.py
+++ b/qxub/cli.py
@@ -21,6 +21,7 @@ from .exec_cli import exec_cli
 from .history_cli import history
 from .interactive_cli import interactive_cli
 from .monitor_cli import monitor_cli
+from .notify_cli import notify_cli
 from .platforms import estimate_cmd, platform_cli, select_queue_cmd, validate_cmd
 from .replay_cli import replay_cli
 from .resources_cli import resources
@@ -74,6 +75,7 @@ qxub.add_command(alias_cli)  # Deprecated - use qxub exec --alias instead
 qxub.add_command(cancel_cli)
 qxub.add_command(history)
 qxub.add_command(monitor_cli)
+qxub.add_command(notify_cli)
 qxub.add_command(resources)
 qxub.add_command(status_cli)
 qxub.add_command(platform_cli)

--- a/qxub/config/handler.py
+++ b/qxub/config/handler.py
@@ -71,6 +71,15 @@ def apply_config_defaults(params, config_manager):
     if not params["resources"]:  # Empty tuple means no resources provided
         params["resources"] = defaults.get("resources", [])
 
+    # Email notification defaults
+    if params.get("email") == "__DISABLED__":
+        # --no-notify was specified, suppress notifications
+        params["email"] = None
+    elif params.get("email") is None:
+        params["email"] = defaults.get("email")
+    if params.get("email_opts") is None:
+        params["email_opts"] = defaults.get("email_opts", "ae")  # abort + end
+
     return params
 
 
@@ -254,6 +263,13 @@ def build_qsub_options(params):
     if params.get("resources"):
         options += " ".join([f"-l {resource}" for resource in params["resources"]])
     options += f" -o {params['joblog']}"
+
+    # Email notifications via PBS -M and -m
+    if params.get("email"):
+        options += f" -M {params['email']}"
+        email_opts = params.get("email_opts", "ae")  # default: abort + end
+        options += f" -m {email_opts}"
+
     return options
 
 

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -645,6 +645,7 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
         "verbose": verbose,
         "cpus_explicit": cpus_explicit,  # Track for graceful adjustment
         "internet": options.get("internet", False),
+        "notify": options.get("notify", False),  # Slack/Discord notifications
     }
 
     # Resolve and merge tags from --tag (multiple) and --tags (comma-separated string)

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -126,6 +126,18 @@ def _get_shortcut_context_description(definition: dict) -> str:
 @click.option(
     "--email-opts", help="PBS email options (e.g., 'abe') (default: configured)"
 )
+@click.option(
+    "--notify",
+    is_flag=True,
+    default=False,
+    help="Enable PBS email notification using configured email address.",
+)
+@click.option(
+    "--no-notify",
+    is_flag=True,
+    default=False,
+    help="Disable PBS email notification (overrides config).",
+)
 @click.option("--array", help="Job array specification (e.g., '1-10' or '1-100:2')")
 @click.option(
     "--tag",
@@ -604,6 +616,14 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
         or any(r.startswith("ncpus=") for r in (options["resources"] or []))
     )
 
+    # Resolve email from --notify/--no-notify/--email options
+    # Priority: --no-notify > --email > config default
+    # --notify is just a clarity flag (notifications use config by default)
+    resolved_email = options["email"]  # May be None, let config supply default
+    if options.get("no_notify"):
+        # Explicitly disable notifications
+        resolved_email = "__DISABLED__"  # Sentinel to suppress config default
+
     # Extract PBS-specific options for processing
     params = {
         "resources": tuple(all_resources),  # Use merged resources
@@ -616,7 +636,7 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
         "joblog": None,  # Will be set by config system
         "execdir": options["execdir"],
         "create_execdir": options["create_execdir"],
-        "email": options["email"],
+        "email": resolved_email,
         "email_opts": options["email_opts"],
         "array": options["array"],
         "dry": options["dry"],

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -175,6 +175,18 @@ def _get_shortcut_context_description(definition: dict) -> str:
 @click.option("--template", help="Custom job script template file")
 @click.option("--pre", help="Command to run before the main command")
 @click.option("--post", help="Command to run after the main command")
+@click.option(
+    "--var",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Environment variable to set in the job (can be used multiple times)",
+)
+@click.option(
+    "--vars",
+    default=None,
+    metavar="VAR_STRING",
+    help='Comma-separated environment variables, e.g. --vars "FOO=bar,BAZ=qux"',
+)
 @click.option("--cmd", help="Command to execute (alternative to positional arguments)")
 @click.option("--shortcut", help="Use a predefined shortcut for execution settings")
 @click.option("--alias", help="Use a predefined alias for execution settings")
@@ -888,6 +900,11 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
         if verbose >= 1:
             click.echo(f"📍 Executing on platform: {platform_name} (local)", err=True)
 
+    # Resolve and merge user environment variables from --var (multiple) and --vars (comma-separated)
+    resolved_vars = list(options.get("var") or [])
+    vars_str = options.get("vars") or ""
+    resolved_vars += [v.strip() for v in vars_str.split(",") if v.strip()]
+
     # Execute the job using unified execution (local path)
     execute_unified(
         ctx,
@@ -897,4 +914,5 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
         pre=options["pre"],
         post=options["post"],
         bind=options["bind"],
+        user_vars=tuple(resolved_vars) if resolved_vars else None,
     )

--- a/qxub/execution/context.py
+++ b/qxub/execution/context.py
@@ -118,7 +118,30 @@ class ExecutionContext:
         db_path = str(get_db_path())
         submission_vars += f",QXUB_SHARED_DB={db_path}"
 
+        # Check if Slack/Discord notifications are configured
+        if ctx_obj.get("notify") and self._has_push_notifications(ctx_obj):
+            submission_vars += ",qxub_notify=true"
+            # Pass output directory for notification context
+            out_dir = str(Path(ctx_obj.get("out", "")).parent)
+            submission_vars += f',qxub_notify_outdir="{out_dir}"'
+
         return submission_vars
+
+    def _has_push_notifications(self, ctx_obj: dict) -> bool:
+        """Check if Slack/Discord notifications are configured."""
+        try:
+            from ..config import manager as config_mod
+
+            config_manager = config_mod.config_manager
+            slack_webhook = config_manager.get_config_value(
+                "notifications.slack.webhook_url"
+            )
+            discord_webhook = config_manager.get_config_value(
+                "notifications.discord.webhook_url"
+            )
+            return bool(slack_webhook or discord_webhook)
+        except Exception:
+            return False
 
     def log_debug_info(
         self,

--- a/qxub/execution/context.py
+++ b/qxub/execution/context.py
@@ -74,8 +74,18 @@ class ExecutionContext:
         pre: str = None,
         post: str = None,
         bind: str = None,
+        user_vars: tuple = None,
     ) -> str:
-        """Build the submission variables string for qsub."""
+        """Build the submission variables string for qsub.
+
+        Args:
+            command: Command tuple to execute
+            ctx_obj: Click context object with job options
+            pre: Pre-command to run before main command
+            post: Post-command to run after main command
+            bind: Singularity bind mounts
+            user_vars: User-defined environment variables (KEY=VALUE tuples)
+        """
         cmd_str = " ".join(command)
         cmd_b64 = base64.b64encode(cmd_str.encode("utf-8")).decode("ascii")
 
@@ -113,6 +123,13 @@ class ExecutionContext:
         if post:
             post_b64 = base64.b64encode(post.encode("utf-8")).decode("ascii")
             submission_vars += f',post_cmd_b64="{post_b64}"'
+
+        # Add user-defined environment variables if provided
+        if user_vars:
+            # Join KEY=VALUE pairs with semicolons and base64 encode to avoid shell escaping issues
+            vars_str = ";".join(user_vars)
+            vars_b64 = base64.b64encode(vars_str.encode("utf-8")).decode("ascii")
+            submission_vars += f',user_vars_b64="{vars_b64}"'
 
         # Pass the resolved DB path so job scripts can write status to the right DB
         db_path = str(get_db_path())
@@ -180,6 +197,7 @@ def execute_unified(
     pre: str = None,
     post: str = None,
     bind: str = None,
+    user_vars: tuple = None,
 ) -> None:
     """Unified execution function for all execution contexts.
 
@@ -191,6 +209,7 @@ def execute_unified(
         pre: Pre-execution command
         post: Post-execution command
         bind: Singularity bind mounts (only used for singularity context)
+        user_vars: User-defined environment variables (KEY=VALUE tuples)
     """
     # Validate execution context
     execution_context.validate()
@@ -206,7 +225,7 @@ def execute_unified(
 
     # Build submission variables
     submission_vars = execution_context.build_submission_vars(
-        command, ctx_obj, pre, post, bind
+        command, ctx_obj, pre, post, bind, user_vars
     )
 
     # Build final submission command

--- a/qxub/jobscripts/qconda.pbs
+++ b/qxub/jobscripts/qconda.pbs
@@ -20,6 +20,10 @@ fi
 if [ -n "$post_cmd_b64" ]; then
     post_cmd=$(echo "$post_cmd_b64" | base64 -d)
 fi
+# Decode user-defined environment variables
+if [ -n "$user_vars_b64" ]; then
+    user_vars=$(echo "$user_vars_b64" | base64 -d)
+fi
 
 echo "💻 Command: $cmd"
 if [ -n "$pre_cmd" ]; then
@@ -184,6 +188,18 @@ fi
 # Switch work directory
 echo "📂 Changing to working directory: $cwd"
 cd $cwd
+
+# Export user-defined environment variables
+if [ -n "$user_vars" ]; then
+    echo "🔧 Setting user-defined environment variables:"
+    IFS=';' read -ra VARS <<< "$user_vars"
+    for var_def in "${VARS[@]}"; do
+        if [ -n "$var_def" ]; then
+            echo "   export $var_def"
+            export "$var_def"
+        fi
+    done
+fi
 
 # Ensure output directories exist and files are accessible (only if not in quiet mode)
 if [ "$quiet" != "true" ]; then

--- a/qxub/jobscripts/qconda.pbs
+++ b/qxub/jobscripts/qconda.pbs
@@ -91,7 +91,7 @@ error_handler() {
     # Queue Slack/Discord notification if enabled
     if [ "$qxub_notify" = "true" ]; then
         echo "📬 Queueing failure notification..."
-        qxub notify queue \
+        qxub exec --internet --terse --default -- qxub notify send \
             --job-id "${PBS_JOBID:-unknown}" \
             --exit-code "$exit_code" \
             --job-name "${PBS_JOBNAME:-unknown}" \
@@ -278,7 +278,7 @@ update_job_status "completed" "0"
 # Queue Slack/Discord notification if enabled
 if [ "$qxub_notify" = "true" ]; then
     echo "📬 Queueing notification job..."
-    qxub notify queue \
+    qxub exec --internet --terse --default -- qxub notify send \
         --job-id "${PBS_JOBID:-unknown}" \
         --exit-code 0 \
         --job-name "${PBS_JOBNAME:-unknown}" \

--- a/qxub/jobscripts/qconda.pbs
+++ b/qxub/jobscripts/qconda.pbs
@@ -88,6 +88,17 @@ error_handler() {
     # Update database status to 'failed'
     update_job_status "failed" "$exit_code"
 
+    # Queue Slack/Discord notification if enabled
+    if [ "$qxub_notify" = "true" ]; then
+        echo "📬 Queueing failure notification..."
+        qxub notify queue \
+            --job-id "${PBS_JOBID:-unknown}" \
+            --exit-code "$exit_code" \
+            --job-name "${PBS_JOBNAME:-unknown}" \
+            --output-dir "${qxub_notify_outdir:-$PWD}" \
+            2>/dev/null || true
+    fi
+
     exit $exit_code
 }
 
@@ -263,5 +274,16 @@ fi
 
 # Update database status to 'completed'
 update_job_status "completed" "0"
+
+# Queue Slack/Discord notification if enabled
+if [ "$qxub_notify" = "true" ]; then
+    echo "📬 Queueing notification job..."
+    qxub notify queue \
+        --job-id "${PBS_JOBID:-unknown}" \
+        --exit-code 0 \
+        --job-name "${PBS_JOBNAME:-unknown}" \
+        --output-dir "${qxub_notify_outdir:-$PWD}" \
+        2>/dev/null || echo "⚠️  Failed to queue notification (non-fatal)"
+fi
 
 echo "🎉 Job completed successfully!"

--- a/qxub/jobscripts/qdefault.pbs
+++ b/qxub/jobscripts/qdefault.pbs
@@ -20,6 +20,10 @@ fi
 if [ -n "$post_cmd_b64" ]; then
     post_cmd=$(echo "$post_cmd_b64" | base64 -d)
 fi
+# Decode user-defined environment variables
+if [ -n "$user_vars_b64" ]; then
+    user_vars=$(echo "$user_vars_b64" | base64 -d)
+fi
 
 echo "💻 Command: $cmd"
 if [ -n "$pre_cmd" ]; then
@@ -135,6 +139,18 @@ fi
 
 # Change to execution directory
 cd "$cwd" || { echo "❌ ERROR: Failed to change to directory $cwd"; exit 1; }
+
+# Export user-defined environment variables
+if [ -n "$user_vars" ]; then
+    echo "🔧 Setting user-defined environment variables:"
+    IFS=';' read -ra VARS <<< "$user_vars"
+    for var_def in "${VARS[@]}"; do
+        if [ -n "$var_def" ]; then
+            echo "   export $var_def"
+            export "$var_def"
+        fi
+    done
+fi
 
 # Set output redirection for quiet mode
 if [ "$quiet" = "true" ]; then

--- a/qxub/jobscripts/qdefault.pbs
+++ b/qxub/jobscripts/qdefault.pbs
@@ -102,7 +102,7 @@ error_handler() {
     # Queue Slack/Discord notification if enabled
     if [ "$qxub_notify" = "true" ]; then
         echo "📬 Queueing failure notification..."
-        qxub notify queue \
+        qxub exec --internet --terse --default -- qxub notify send \
             --job-id "${PBS_JOBID:-unknown}" \
             --exit-code "$exit_code" \
             --job-name "${PBS_JOBNAME:-unknown}" \
@@ -242,7 +242,7 @@ update_job_status "completed" "0"
 # Queue Slack/Discord notification if enabled
 if [ "$qxub_notify" = "true" ]; then
     echo "📬 Queueing notification job..."
-    qxub notify queue \
+    qxub exec --internet --terse --default -- qxub notify send \
         --job-id "${PBS_JOBID:-unknown}" \
         --exit-code 0 \
         --job-name "${PBS_JOBNAME:-unknown}" \

--- a/qxub/jobscripts/qdefault.pbs
+++ b/qxub/jobscripts/qdefault.pbs
@@ -99,6 +99,17 @@ error_handler() {
     # Update database status to 'failed'
     update_job_status "failed" "$exit_code"
 
+    # Queue Slack/Discord notification if enabled
+    if [ "$qxub_notify" = "true" ]; then
+        echo "📬 Queueing failure notification..."
+        qxub notify queue \
+            --job-id "${PBS_JOBID:-unknown}" \
+            --exit-code "$exit_code" \
+            --job-name "${PBS_JOBNAME:-unknown}" \
+            --output-dir "${qxub_notify_outdir:-$PWD}" \
+            2>/dev/null || true
+    fi
+
     exit $exit_code
 }
 
@@ -227,5 +238,16 @@ echo "$(date -Iseconds)" >> "$STATUS_DIR/final_exit_code_${PBS_JOBID:-unknown}"
 
 # Update database status to 'completed'
 update_job_status "completed" "0"
+
+# Queue Slack/Discord notification if enabled
+if [ "$qxub_notify" = "true" ]; then
+    echo "📬 Queueing notification job..."
+    qxub notify queue \
+        --job-id "${PBS_JOBID:-unknown}" \
+        --exit-code 0 \
+        --job-name "${PBS_JOBNAME:-unknown}" \
+        --output-dir "${qxub_notify_outdir:-$PWD}" \
+        2>/dev/null || echo "⚠️  Failed to queue notification (non-fatal)"
+fi
 
 echo "🎉 Job completed successfully"

--- a/qxub/jobscripts/qmod.pbs
+++ b/qxub/jobscripts/qmod.pbs
@@ -90,6 +90,18 @@ error_handler() {
     echo "$exit_code" > "$STATUS_DIR/final_exit_code_${PBS_JOBID:-unknown}"
     echo "$(date -Iseconds)" >> "$STATUS_DIR/final_exit_code_${PBS_JOBID:-unknown}"
     update_job_status "failed" "$exit_code"
+
+    # Queue Slack/Discord notification if enabled
+    if [ "$qxub_notify" = "true" ]; then
+        echo "📬 Queueing failure notification..."
+        qxub notify queue \
+            --job-id "${PBS_JOBID:-unknown}" \
+            --exit-code "$exit_code" \
+            --job-name "${PBS_JOBNAME:-unknown}" \
+            --output-dir "${qxub_notify_outdir:-$PWD}" \
+            2>/dev/null || true
+    fi
+
     exit $exit_code
 }
 
@@ -217,4 +229,16 @@ if [ -n "$modules" ]; then
 fi
 
 update_job_status "completed" "0"
+
+# Queue Slack/Discord notification if enabled
+if [ "$qxub_notify" = "true" ]; then
+    echo "📬 Queueing notification job..."
+    qxub notify queue \
+        --job-id "${PBS_JOBID:-unknown}" \
+        --exit-code 0 \
+        --job-name "${PBS_JOBNAME:-unknown}" \
+        --output-dir "${qxub_notify_outdir:-$PWD}" \
+        2>/dev/null || echo "⚠️  Failed to queue notification (non-fatal)"
+fi
+
 echo "🎉 Job completed successfully!"

--- a/qxub/jobscripts/qmod.pbs
+++ b/qxub/jobscripts/qmod.pbs
@@ -64,6 +64,10 @@ fi
 if [ -n "$post_cmd_b64" ]; then
     post_cmd=$(echo "$post_cmd_b64" | base64 -d)
 fi
+# Decode user-defined environment variables
+if [ -n "$user_vars_b64" ]; then
+    user_vars=$(echo "$user_vars_b64" | base64 -d)
+fi
 
 echo "💻 Command: $cmd"
 if [ -n "$pre_cmd" ]; then
@@ -128,6 +132,18 @@ fi
 # Switch work directory
 echo "📂 Changing to working directory: $cwd"
 cd $cwd
+
+# Export user-defined environment variables
+if [ -n "$user_vars" ]; then
+    echo "🔧 Setting user-defined environment variables:"
+    IFS=';' read -ra VARS <<< "$user_vars"
+    for var_def in "${VARS[@]}"; do
+        if [ -n "$var_def" ]; then
+            echo "   export $var_def"
+            export "$var_def"
+        fi
+    done
+fi
 
 # Ensure output directories exist and files are accessible (only if not in quiet mode)
 if [ "$quiet" != "true" ]; then

--- a/qxub/jobscripts/qmod.pbs
+++ b/qxub/jobscripts/qmod.pbs
@@ -94,7 +94,7 @@ error_handler() {
     # Queue Slack/Discord notification if enabled
     if [ "$qxub_notify" = "true" ]; then
         echo "📬 Queueing failure notification..."
-        qxub notify queue \
+        qxub exec --internet --terse --default -- qxub notify send \
             --job-id "${PBS_JOBID:-unknown}" \
             --exit-code "$exit_code" \
             --job-name "${PBS_JOBNAME:-unknown}" \
@@ -233,7 +233,7 @@ update_job_status "completed" "0"
 # Queue Slack/Discord notification if enabled
 if [ "$qxub_notify" = "true" ]; then
     echo "📬 Queueing notification job..."
-    qxub notify queue \
+    qxub exec --internet --terse --default -- qxub notify send \
         --job-id "${PBS_JOBID:-unknown}" \
         --exit-code 0 \
         --job-name "${PBS_JOBNAME:-unknown}" \

--- a/qxub/jobscripts/qsing.pbs
+++ b/qxub/jobscripts/qsing.pbs
@@ -95,7 +95,7 @@ error_handler() {
     # Queue Slack/Discord notification if enabled
     if [ "$qxub_notify" = "true" ]; then
         echo "📬 Queueing failure notification..."
-        qxub notify queue \
+        qxub exec --internet --terse --default -- qxub notify send \
             --job-id "${PBS_JOBID:-unknown}" \
             --exit-code "$exit_code" \
             --job-name "${PBS_JOBNAME:-unknown}" \
@@ -227,7 +227,7 @@ update_job_status "completed" "0"
 # Queue Slack/Discord notification if enabled
 if [ "$qxub_notify" = "true" ]; then
     echo "📬 Queueing notification job..."
-    qxub notify queue \
+    qxub exec --internet --terse --default -- qxub notify send \
         --job-id "${PBS_JOBID:-unknown}" \
         --exit-code 0 \
         --job-name "${PBS_JOBNAME:-unknown}" \

--- a/qxub/jobscripts/qsing.pbs
+++ b/qxub/jobscripts/qsing.pbs
@@ -65,6 +65,10 @@ fi
 if [ -n "$post_cmd_b64" ]; then
     post_cmd=$(echo "$post_cmd_b64" | base64 -d)
 fi
+# Decode user-defined environment variables
+if [ -n "$user_vars_b64" ]; then
+    user_vars=$(echo "$user_vars_b64" | base64 -d)
+fi
 
 echo "💻 Container command: $cmd"
 if [ -n "$pre_cmd" ]; then
@@ -122,6 +126,18 @@ fi
 # Switch work directory
 echo "📂 Changing to working directory: $cwd"
 cd $cwd
+
+# Export user-defined environment variables
+if [ -n "$user_vars" ]; then
+    echo "🔧 Setting user-defined environment variables:"
+    IFS=';' read -ra VARS <<< "$user_vars"
+    for var_def in "${VARS[@]}"; do
+        if [ -n "$var_def" ]; then
+            echo "   export $var_def"
+            export "$var_def"
+        fi
+    done
+fi
 
 # Ensure output directories exist and files are accessible (only if not in quiet mode)
 if [ "$quiet" != "true" ]; then

--- a/qxub/jobscripts/qsing.pbs
+++ b/qxub/jobscripts/qsing.pbs
@@ -91,6 +91,18 @@ error_handler() {
     echo "$exit_code" > "$STATUS_DIR/final_exit_code_${PBS_JOBID:-unknown}"
     echo "$(date -Iseconds)" >> "$STATUS_DIR/final_exit_code_${PBS_JOBID:-unknown}"
     update_job_status "failed" "$exit_code"
+
+    # Queue Slack/Discord notification if enabled
+    if [ "$qxub_notify" = "true" ]; then
+        echo "📬 Queueing failure notification..."
+        qxub notify queue \
+            --job-id "${PBS_JOBID:-unknown}" \
+            --exit-code "$exit_code" \
+            --job-name "${PBS_JOBNAME:-unknown}" \
+            --output-dir "${qxub_notify_outdir:-$PWD}" \
+            2>/dev/null || true
+    fi
+
     exit $exit_code
 }
 
@@ -211,4 +223,16 @@ else
 fi
 
 update_job_status "completed" "0"
+
+# Queue Slack/Discord notification if enabled
+if [ "$qxub_notify" = "true" ]; then
+    echo "📬 Queueing notification job..."
+    qxub notify queue \
+        --job-id "${PBS_JOBID:-unknown}" \
+        --exit-code 0 \
+        --job-name "${PBS_JOBNAME:-unknown}" \
+        --output-dir "${qxub_notify_outdir:-$PWD}" \
+        2>/dev/null || echo "⚠️  Failed to queue notification (non-fatal)"
+fi
+
 echo "🎉 Job completed successfully!"

--- a/qxub/notifications/__init__.py
+++ b/qxub/notifications/__init__.py
@@ -1,0 +1,92 @@
+"""
+Notification channels for qxub job completion.
+
+This module provides functions to send notifications via various channels
+(Slack, Discord, etc.) when PBS jobs complete.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def send_all_notifications(context: Dict[str, Any], config_manager) -> List[str]:
+    """Send notifications to all configured channels.
+
+    Args:
+        context: Dictionary with job information:
+            - job_id: PBS job ID
+            - exit_code: Job exit code
+            - job_name: Job name
+            - status: "SUCCESS" or "FAILED"
+            - output_tail: Last N lines of output (optional)
+        config_manager: qxub ConfigManager instance
+
+    Returns:
+        List of channel names that were successfully notified.
+
+    Raises:
+        Exception: If all configured channels fail.
+    """
+    channels_sent = []
+    errors = []
+
+    # Check Slack
+    slack_webhook = config_manager.get_config_value("notifications.slack.webhook_url")
+    if slack_webhook:
+        try:
+            send_slack(context, config_manager)
+            channels_sent.append("slack")
+        except Exception as e:
+            logger.error("Slack notification failed: %s", e)
+            errors.append(f"Slack: {e}")
+
+    # Check Discord
+    discord_webhook = config_manager.get_config_value(
+        "notifications.discord.webhook_url"
+    )
+    if discord_webhook:
+        try:
+            send_discord(context, config_manager)
+            channels_sent.append("discord")
+        except Exception as e:
+            logger.error("Discord notification failed: %s", e)
+            errors.append(f"Discord: {e}")
+
+    if not channels_sent and errors:
+        raise Exception(f"All notification channels failed: {'; '.join(errors)}")
+
+    return channels_sent
+
+
+def send_slack(context: Dict[str, Any], config_manager) -> None:
+    """Send notification to Slack.
+
+    Args:
+        context: Job context dictionary.
+        config_manager: qxub ConfigManager instance.
+
+    Raises:
+        Exception: If sending fails.
+    """
+    from .slack import SlackNotifier
+
+    notifier = SlackNotifier(config_manager)
+    notifier.send(context)
+
+
+def send_discord(context: Dict[str, Any], config_manager) -> None:
+    """Send notification to Discord.
+
+    Args:
+        context: Job context dictionary.
+        config_manager: qxub ConfigManager instance.
+
+    Raises:
+        Exception: If sending fails.
+    """
+    from .discord import DiscordNotifier
+
+    notifier = DiscordNotifier(config_manager)
+    notifier.send(context)

--- a/qxub/notifications/discord.py
+++ b/qxub/notifications/discord.py
@@ -1,0 +1,120 @@
+"""
+Discord notification channel for qxub.
+
+Uses Discord webhook to post notifications.
+
+Configuration:
+    notifications:
+      discord:
+        webhook_url: "https://discord.com/api/webhooks/..."
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordNotifier:
+    """Send notifications to Discord."""
+
+    def __init__(self, config_manager):
+        self.config_manager = config_manager
+        self.webhook_url = self._resolve_env(
+            config_manager.get_config_value("notifications.discord.webhook_url")
+        )
+
+    def _resolve_env(self, value: Optional[str]) -> Optional[str]:
+        """Resolve environment variable references like ${VAR}."""
+        if not value:
+            return value
+        if value.startswith("${") and value.endswith("}"):
+            env_var = value[2:-1]
+            return os.environ.get(env_var)
+        return value
+
+    def send(self, context: Dict[str, Any]) -> None:
+        """Send notification to Discord.
+
+        Args:
+            context: Job context with job_id, exit_code, status, etc.
+
+        Raises:
+            Exception: If sending fails.
+        """
+        if not self.webhook_url:
+            raise ValueError("Discord webhook_url not configured")
+
+        payload = self._build_message(context)
+
+        data = json.dumps(payload).encode("utf-8")
+        request = Request(
+            self.webhook_url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+
+        try:
+            with urlopen(request, timeout=30) as response:
+                # Discord returns 204 No Content on success
+                if response.status not in (200, 204):
+                    raise Exception(f"Discord webhook returned {response.status}")
+        except HTTPError as e:
+            raise Exception(f"Discord webhook failed: {e.code} {e.reason}")
+        except URLError as e:
+            raise Exception(f"Discord webhook connection failed: {e.reason}")
+
+    def _build_message(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Build Discord message payload using embeds."""
+        job_id = context.get("job_id", "unknown")
+        job_name = context.get("job_name", job_id.split(".")[0])
+        status = context.get("status", "UNKNOWN")
+        exit_code = context.get("exit_code", "?")
+        output_tail = context.get("output_tail")
+
+        # Status emoji and color
+        if status == "SUCCESS":
+            emoji = "✅"
+            color = 0x00FF00  # Green
+        else:
+            emoji = "❌"
+            color = 0xFF0000  # Red
+
+        # Build embed
+        embed = {
+            "title": f"{emoji} Job {status}: {job_name}",
+            "color": color,
+            "fields": [
+                {"name": "Job ID", "value": f"`{job_id}`", "inline": True},
+                {"name": "Exit Code", "value": f"`{exit_code}`", "inline": True},
+            ],
+        }
+
+        # Add output tail if available
+        if output_tail:
+            # Discord has a 1024 char limit per field
+            truncated = output_tail[:1000]
+            embed["fields"].append(
+                {
+                    "name": "Last 10 lines of output",
+                    "value": f"```\n{truncated}\n```",
+                    "inline": False,
+                }
+            )
+
+        # Add helpful commands in footer
+        embed["footer"] = {
+            "text": (
+                f"View output: qxub history show {job_id} --output | "
+                f"View logs: qxub history show {job_id} --logs"
+            )
+        }
+
+        return {
+            "content": None,  # No plain text, just embed
+            "embeds": [embed],
+        }

--- a/qxub/notifications/slack.py
+++ b/qxub/notifications/slack.py
@@ -1,0 +1,205 @@
+"""
+Slack notification channel for qxub.
+
+Supports two modes:
+1. Incoming Webhook: Posts to a channel via webhook URL
+2. Bot Token + User ID: Sends DM to a specific user
+
+Configuration:
+    notifications:
+      slack:
+        webhook_url: "https://hooks.slack.com/services/..."  # Option 1
+        # OR
+        bot_token: "${QXUB_SLACK_BOT_TOKEN}"  # Option 2
+        user_id: "U12345ABCDE"
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+
+class SlackNotifier:
+    """Send notifications to Slack."""
+
+    def __init__(self, config_manager):
+        self.config_manager = config_manager
+        self.webhook_url = self._resolve_env(
+            config_manager.get_config_value("notifications.slack.webhook_url")
+        )
+        self.bot_token = self._resolve_env(
+            config_manager.get_config_value("notifications.slack.bot_token")
+        )
+        self.user_id = config_manager.get_config_value("notifications.slack.user_id")
+
+    def _resolve_env(self, value: Optional[str]) -> Optional[str]:
+        """Resolve environment variable references like ${VAR}."""
+        if not value:
+            return value
+        if value.startswith("${") and value.endswith("}"):
+            env_var = value[2:-1]
+            return os.environ.get(env_var)
+        return value
+
+    def send(self, context: Dict[str, Any]) -> None:
+        """Send notification to Slack.
+
+        Args:
+            context: Job context with job_id, exit_code, status, etc.
+
+        Raises:
+            Exception: If sending fails.
+        """
+        if self.webhook_url:
+            self._send_webhook(context)
+        elif self.bot_token and self.user_id:
+            self._send_dm(context)
+        else:
+            raise ValueError(
+                "Slack not configured: set webhook_url or (bot_token + user_id)"
+            )
+
+    def _send_webhook(self, context: Dict[str, Any]) -> None:
+        """Send via incoming webhook."""
+        payload = self._build_message(context)
+
+        data = json.dumps(payload).encode("utf-8")
+        request = Request(
+            self.webhook_url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+
+        try:
+            with urlopen(request, timeout=30) as response:
+                if response.status != 200:
+                    raise Exception(f"Slack webhook returned {response.status}")
+        except HTTPError as e:
+            raise Exception(f"Slack webhook failed: {e.code} {e.reason}")
+        except URLError as e:
+            raise Exception(f"Slack webhook connection failed: {e.reason}")
+
+    def _send_dm(self, context: Dict[str, Any]) -> None:
+        """Send DM via Bot API."""
+        # First, open a conversation with the user
+        conv_url = "https://slack.com/api/conversations.open"
+        conv_data = json.dumps({"users": self.user_id}).encode("utf-8")
+        conv_request = Request(
+            conv_url,
+            data=conv_data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.bot_token}",
+            },
+        )
+
+        try:
+            with urlopen(conv_request, timeout=30) as response:
+                result = json.loads(response.read().decode("utf-8"))
+                if not result.get("ok"):
+                    raise Exception(f"Failed to open DM: {result.get('error')}")
+                channel_id = result["channel"]["id"]
+        except HTTPError as e:
+            raise Exception(f"Slack API failed: {e.code} {e.reason}")
+        except URLError as e:
+            raise Exception(f"Slack API connection failed: {e.reason}")
+
+        # Send the message
+        payload = self._build_message(context)
+        payload["channel"] = channel_id
+
+        msg_url = "https://slack.com/api/chat.postMessage"
+        msg_data = json.dumps(payload).encode("utf-8")
+        msg_request = Request(
+            msg_url,
+            data=msg_data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.bot_token}",
+            },
+        )
+
+        try:
+            with urlopen(msg_request, timeout=30) as response:
+                result = json.loads(response.read().decode("utf-8"))
+                if not result.get("ok"):
+                    raise Exception(f"Failed to send message: {result.get('error')}")
+        except HTTPError as e:
+            raise Exception(f"Slack API failed: {e.code} {e.reason}")
+        except URLError as e:
+            raise Exception(f"Slack API connection failed: {e.reason}")
+
+    def _build_message(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Build Slack message payload using Block Kit."""
+        job_id = context.get("job_id", "unknown")
+        job_name = context.get("job_name", job_id.split(".")[0])
+        status = context.get("status", "UNKNOWN")
+        exit_code = context.get("exit_code", "?")
+        output_tail = context.get("output_tail")
+
+        # Status emoji and color
+        if status == "SUCCESS":
+            emoji = "✅"
+            color = "good"
+        else:
+            emoji = "❌"
+            color = "danger"
+
+        # Build blocks
+        blocks = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": f"{emoji} Job {status}: {job_name}",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {"type": "mrkdwn", "text": f"*Job ID:*\n`{job_id}`"},
+                    {"type": "mrkdwn", "text": f"*Exit Code:*\n`{exit_code}`"},
+                ],
+            },
+        ]
+
+        # Add output tail if available
+        if output_tail:
+            blocks.append({"type": "divider"})
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*Last 10 lines of output:*\n```{output_tail[:2000]}```",
+                    },
+                }
+            )
+
+        # Add helpful commands
+        blocks.append({"type": "divider"})
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"View output: `qxub history show {job_id} --output`\n"
+                            f"View logs: `qxub history show {job_id} --logs`"
+                        ),
+                    }
+                ],
+            }
+        )
+
+        return {
+            "text": f"{emoji} Job {status}: {job_name} ({job_id})",  # Fallback
+            "blocks": blocks,
+        }

--- a/qxub/notify_cli.py
+++ b/qxub/notify_cli.py
@@ -5,20 +5,14 @@ Provides the `qxub notify` command for sending notifications via Slack,
 Discord, or other channels when jobs complete.
 
 Architecture:
-- Job script calls `qxub notify --job-id X --exit-code N` at completion
-- This submits a tiny job to a data-mover queue (has internet access)
-- The data-mover job calls `qxub notify --send ...` to actually send
-
-This two-stage approach is needed because compute nodes typically lack
-internet access on HPC systems.
+- Job script calls: qxub exec --internet --terse --default -- qxub notify send ...
+- The notification runs on an internet-capable queue (e.g., copyq)
+- This approach reuses qxub exec's queue selection instead of duplicating logic
 """
 
-import json
 import logging
-import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 
@@ -29,86 +23,6 @@ logger = logging.getLogger(__name__)
 def notify_cli():
     """Send job completion notifications (Slack, Discord, etc.)."""
     pass
-
-
-@notify_cli.command(name="queue")
-@click.option("--job-id", required=True, help="PBS job ID of the completed job")
-@click.option("--exit-code", type=int, required=True, help="Exit code of the job")
-@click.option("--job-name", default=None, help="Job name (for notification message)")
-@click.option(
-    "--output-dir",
-    default=None,
-    help="Directory containing job output files (for including tail in notification)",
-)
-@click.option(
-    "--dry-run", is_flag=True, help="Show what would be done without submitting"
-)
-def queue_notification(job_id, exit_code, job_name, output_dir, dry_run):
-    """Queue a notification job on a data-mover node with internet access.
-
-    This is called from job scripts at completion. It submits a small job
-    to an internet-capable queue that will send the actual notification.
-    """
-    from .config import manager as config_mod
-    from .execution import submit_job
-
-    config_manager = config_mod.config_manager
-
-    # Check if notifications are configured
-    slack_webhook = config_manager.get_config_value("notifications.slack.webhook_url")
-    slack_user_id = config_manager.get_config_value("notifications.slack.user_id")
-    discord_webhook = config_manager.get_config_value(
-        "notifications.discord.webhook_url"
-    )
-
-    if not any([slack_webhook, slack_user_id, discord_webhook]):
-        logger.debug("No notification channels configured, skipping")
-        return
-
-    # Build the notification command
-    notify_cmd = [
-        "qxub",
-        "notify",
-        "send",
-        "--job-id",
-        job_id,
-        "--exit-code",
-        str(exit_code),
-    ]
-
-    if job_name:
-        notify_cmd.extend(["--job-name", job_name])
-
-    if output_dir:
-        notify_cmd.extend(["--output-dir", output_dir])
-
-    # Get project from config for the notification job
-    project = config_manager.get_config_value("defaults.project") or os.getenv(
-        "PROJECT"
-    )
-
-    # Get the internet-capable queue (default: copyq for NCI Gadi)
-    notify_queue = config_manager.get_config_value("notifications.queue") or "copyq"
-
-    if dry_run:
-        click.echo(f"Would submit notification job: {' '.join(notify_cmd)}")
-        click.echo(f"  Project: {project}")
-        click.echo(f"  Queue: {notify_queue}")
-        return
-
-    try:
-        # Submit a tiny job to send the notification on internet-capable queue
-        result = submit_job(
-            command=tuple(notify_cmd),
-            resources={"walltime": "00:05:00", "mem": "1GB", "ncpus": 1},
-            name=f"notify-{job_id.split('.')[0]}",
-            project=project,
-            queue=notify_queue,
-        )
-        logger.info("Queued notification job %s for job %s", result.job_id, job_id)
-    except Exception as e:
-        # Don't fail the main job if notification fails
-        logger.warning("Failed to queue notification job: %s", e)
 
 
 @notify_cli.command(name="send")

--- a/qxub/notify_cli.py
+++ b/qxub/notify_cli.py
@@ -1,0 +1,222 @@
+"""
+Notify CLI for qxub - Send job completion notifications.
+
+Provides the `qxub notify` command for sending notifications via Slack,
+Discord, or other channels when jobs complete.
+
+Architecture:
+- Job script calls `qxub notify --job-id X --exit-code N` at completion
+- This submits a tiny job to a data-mover queue (has internet access)
+- The data-mover job calls `qxub notify --send ...` to actually send
+
+This two-stage approach is needed because compute nodes typically lack
+internet access on HPC systems.
+"""
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+@click.group(name="notify")
+def notify_cli():
+    """Send job completion notifications (Slack, Discord, etc.)."""
+    pass
+
+
+@notify_cli.command(name="queue")
+@click.option("--job-id", required=True, help="PBS job ID of the completed job")
+@click.option("--exit-code", type=int, required=True, help="Exit code of the job")
+@click.option("--job-name", default=None, help="Job name (for notification message)")
+@click.option(
+    "--output-dir",
+    default=None,
+    help="Directory containing job output files (for including tail in notification)",
+)
+@click.option(
+    "--dry-run", is_flag=True, help="Show what would be done without submitting"
+)
+def queue_notification(job_id, exit_code, job_name, output_dir, dry_run):
+    """Queue a notification job on a data-mover node with internet access.
+
+    This is called from job scripts at completion. It submits a small job
+    to an internet-capable queue that will send the actual notification.
+    """
+    from .config import manager as config_mod
+    from .execution import submit_job
+
+    config_manager = config_mod.config_manager
+
+    # Check if notifications are configured
+    slack_webhook = config_manager.get_config_value("notifications.slack.webhook_url")
+    slack_user_id = config_manager.get_config_value("notifications.slack.user_id")
+    discord_webhook = config_manager.get_config_value(
+        "notifications.discord.webhook_url"
+    )
+
+    if not any([slack_webhook, slack_user_id, discord_webhook]):
+        logger.debug("No notification channels configured, skipping")
+        return
+
+    # Build the notification command
+    notify_cmd = [
+        "qxub",
+        "notify",
+        "send",
+        "--job-id",
+        job_id,
+        "--exit-code",
+        str(exit_code),
+    ]
+
+    if job_name:
+        notify_cmd.extend(["--job-name", job_name])
+
+    if output_dir:
+        notify_cmd.extend(["--output-dir", output_dir])
+
+    # Get project from config for the notification job
+    project = config_manager.get_config_value("defaults.project") or os.getenv(
+        "PROJECT"
+    )
+
+    # Get the internet-capable queue (default: copyq for NCI Gadi)
+    notify_queue = config_manager.get_config_value("notifications.queue") or "copyq"
+
+    if dry_run:
+        click.echo(f"Would submit notification job: {' '.join(notify_cmd)}")
+        click.echo(f"  Project: {project}")
+        click.echo(f"  Queue: {notify_queue}")
+        return
+
+    try:
+        # Submit a tiny job to send the notification on internet-capable queue
+        result = submit_job(
+            command=tuple(notify_cmd),
+            resources={"walltime": "00:05:00", "mem": "1GB", "ncpus": 1},
+            name=f"notify-{job_id.split('.')[0]}",
+            project=project,
+            queue=notify_queue,
+        )
+        logger.info("Queued notification job %s for job %s", result.job_id, job_id)
+    except Exception as e:
+        # Don't fail the main job if notification fails
+        logger.warning("Failed to queue notification job: %s", e)
+
+
+@notify_cli.command(name="send")
+@click.option("--job-id", required=True, help="PBS job ID of the completed job")
+@click.option("--exit-code", type=int, required=True, help="Exit code of the job")
+@click.option("--job-name", default=None, help="Job name")
+@click.option(
+    "--output-dir", default=None, help="Directory containing job output files"
+)
+def send_notification(job_id, exit_code, job_name, output_dir):
+    """Send notification to configured channels (Slack, Discord, etc.).
+
+    This is called by the data-mover job to actually send the notification.
+    It runs on a node with internet access.
+    """
+    from .config import manager as config_mod
+    from .notifications import send_all_notifications
+
+    config_manager = config_mod.config_manager
+
+    # Build notification context
+    context = {
+        "job_id": job_id,
+        "exit_code": exit_code,
+        "job_name": job_name or job_id.split(".")[0],
+        "status": "SUCCESS" if exit_code == 0 else "FAILED",
+        "output_tail": None,
+    }
+
+    # Try to get last 10 lines of output
+    if output_dir:
+        out_files = list(Path(output_dir).glob("*.out"))
+        if out_files:
+            try:
+                with open(out_files[0]) as f:
+                    lines = f.readlines()
+                    context["output_tail"] = "".join(lines[-10:])
+            except Exception as e:
+                logger.debug("Could not read output file: %s", e)
+
+    # Send to all configured channels
+    try:
+        send_all_notifications(context, config_manager)
+        click.echo(f"✅ Notification sent for job {job_id}")
+    except Exception as e:
+        click.echo(f"❌ Failed to send notification: {e}", err=True)
+        sys.exit(1)
+
+
+@notify_cli.command(name="test")
+@click.argument(
+    "channel", type=click.Choice(["slack", "discord", "all"]), default="all"
+)
+def test_notification(channel):
+    """Send a test notification to verify configuration.
+
+    Example:
+        qxub notify test slack
+        qxub notify test all
+    """
+    from .config import manager as config_mod
+    from .notifications import send_all_notifications, send_discord, send_slack
+
+    config_manager = config_mod.config_manager
+
+    test_context = {
+        "job_id": "test-12345.gadi-pbs",
+        "exit_code": 0,
+        "job_name": "qxub-notify-test",
+        "status": "SUCCESS",
+        "output_tail": "This is a test notification from qxub.\nConfiguration is working correctly!",
+    }
+
+    channels_sent = []
+
+    if channel in ("slack", "all"):
+        webhook = config_manager.get_config_value("notifications.slack.webhook_url")
+        if webhook:
+            try:
+                send_slack(test_context, config_manager)
+                channels_sent.append("slack")
+                click.echo("✅ Slack test notification sent")
+            except Exception as e:
+                click.echo(f"❌ Slack failed: {e}", err=True)
+        else:
+            click.echo("⚠️  Slack not configured (set notifications.slack.webhook_url)")
+
+    if channel in ("discord", "all"):
+        webhook = config_manager.get_config_value("notifications.discord.webhook_url")
+        if webhook:
+            try:
+                send_discord(test_context, config_manager)
+                channels_sent.append("discord")
+                click.echo("✅ Discord test notification sent")
+            except Exception as e:
+                click.echo(f"❌ Discord failed: {e}", err=True)
+        else:
+            click.echo(
+                "⚠️  Discord not configured (set notifications.discord.webhook_url)"
+            )
+
+    if not channels_sent:
+        click.echo("\nNo notification channels are configured.")
+        click.echo("Configure with:")
+        click.echo(
+            '  qxub config set notifications.slack.webhook_url "https://hooks.slack.com/..."'
+        )
+        click.echo(
+            '  qxub config set notifications.discord.webhook_url "https://discord.com/api/webhooks/..."'
+        )
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Add CLI options to pass user-defined environment variables to PBS jobs.

## New Options

- `--var KEY=VALUE` - Set a single environment variable (can be used multiple times)
- `--vars "FOO=bar,BAZ=qux"` - Set multiple variables via comma-separated string

## Usage Examples

```bash
# Single variable
qxub exec --var "MY_VAR=value" --env base -- echo '$MY_VAR'

# Multiple variables with --var
qxub exec --var "FOO=bar" --var "BAZ=qux" --default -- 'echo $FOO $BAZ'

# Using --vars for comma-separated list
qxub exec --vars "FOO=bar,BAZ=qux" --default -- echo test

# Both options together
qxub exec --var "A=1" --vars "B=2,C=3" --default -- echo test
```

## Implementation

- Variables are joined with semicolons and base64 encoded to avoid shell escaping issues
- Passed to PBS via `user_vars_b64` qsub variable
- All job templates (qconda.pbs, qdefault.pbs, qmod.pbs, qsing.pbs) decode and `export` each variable before command execution

## Files Changed

- `qxub/exec_cli.py` - Added `--var` and `--vars` CLI options
- `qxub/execution/context.py` - Updated `execute_unified()` and `build_submission_vars()` to handle user variables
- `qxub/jobscripts/*.pbs` - All 4 templates updated to decode and export user variables