### PR TITLE
feat: add --gpus and --gpu-type options with auto queue selection

### DIFF
--- a/docs/platforms/nci_gadi.yaml
+++ b/docs/platforms/nci_gadi.yaml
@@ -185,6 +185,23 @@ platform:
         max_jobs_queued: 300
         min_memory: "1000GB"
       priority: normal
+      su_billing_rate: 5.0
+      walltime_rules:
+        - cores: "1-48"
+          max_walltime: "48:00:00"
+        - cores: "96"
+          max_walltime: "24:00:00"
+
+    - name: megamembw
+      type: megamem
+      limits:
+        max_cpus: 64
+        max_memory: "3000GB"
+        max_walltime: "48:00:00"
+        max_jobs_per_user: 50
+        max_jobs_queued: 300
+        min_memory: "1500GB"
+      priority: normal
       su_billing_rate: 1.25
       walltime_rules:
         - cores: "32"
@@ -194,6 +211,8 @@ platform:
 
     - name: gpuvolta
       type: gpu
+      gpu_type: v100
+      cpus_per_gpu: 12
       limits:
         max_cpus: 960
         max_memory: "382GB"
@@ -210,6 +229,27 @@ platform:
         - cores: "144-192"
           max_walltime: "24:00:00"
         - cores: "240-960"
+          max_walltime: "5:00:00"
+
+    - name: dgxa100
+      type: gpu
+      gpu_type: a100
+      cpus_per_gpu: 16
+      limits:
+        max_cpus: 256
+        max_memory: "2000GB"
+        max_local_storage: "28TB"
+        max_walltime: "48:00:00"
+        max_jobs_per_user: 50
+        max_jobs_queued: 50
+        max_gpus: 8
+        min_gpus: 1
+      priority: normal
+      su_billing_rate: 4.5
+      walltime_rules:
+        - cores: "16-128"
+          max_walltime: "48:00:00"
+        - cores: "144-256"
           max_walltime: "5:00:00"
 
     - name: copyq
@@ -229,6 +269,10 @@ platform:
   # Optimized for cost-effectiveness and resource availability
   # Rules are evaluated in order - most specific conditions first
   auto_selection_rules:
+    - condition: "gpu_type == a100"
+      queue: dgxa100
+    - condition: "gpu_type == v100"
+      queue: gpuvolta
     - condition: "gpu_requested > 0"
       queue: gpuvolta
     - condition: "memory >= 1000GB"
@@ -257,3 +301,4 @@ platform:
     hugemembw: "select_from_options(cores, [7, 14, 21, 28])"
     megamem: "select_from_options(cores, [32, 64])"
     gpuvolta: "round_cores_to_multiple(cores, 12)"
+    dgxa100: "round_cores_to_multiple(cores, 16)"

--- a/qxub/__init__.py
+++ b/qxub/__init__.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"
 
 # Library-standard NullHandler: prevents "No handler found" warnings and
 # avoids triggering basicConfig() when qxub is used as a library.

--- a/qxub/config/handler.py
+++ b/qxub/config/handler.py
@@ -153,8 +153,8 @@ def select_auto_queue(params):
     try:
         from pathlib import Path
 
+        from ..platforms.core import PlatformLoader
         from ..resources import parse_walltime  # noqa: F811
-        from .platforms import PlatformLoader
 
         # Check for QXUB_PLATFORM_PATHS environment variable
         platform_paths_env = os.environ.get("QXUB_PLATFORM_PATHS")
@@ -199,6 +199,10 @@ def select_auto_queue(params):
         # Add internet connectivity requirement if specified
         if params.get("internet"):
             requirements["internet"] = True
+
+        # Add GPU type for queue selection if specified
+        if params.get("gpu_type"):
+            requirements["gpu_type"] = params["gpu_type"].lower()
 
         # Try to find best queue from any platform
         best_queue = None

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -77,6 +77,16 @@ def _get_shortcut_context_description(definition: dict) -> str:
     help="Local disk/jobfs requirement (workflow-friendly). Examples: '10GB', '500MB'. (default: configured). Converted to PBS format automatically.",
 )
 @click.option(
+    "--gpus",
+    type=int,
+    help="Number of GPUs (workflow-friendly). Triggers automatic GPU queue selection. Converted to PBS ngpus automatically.",
+)
+@click.option(
+    "--gpu-type",
+    type=click.Choice(["v100", "a100"], case_sensitive=False),
+    help="GPU type to request (v100=gpuvolta, a100=dgxa100). Used with --gpus for queue selection.",
+)
+@click.option(
     "--volumes",
     "--storage",
     help="Storage volumes to mount (NCI format). Examples: 'gdata/a56', 'gdata/a56+gdata/px14'. (default: configured). Converted to PBS storage= automatically.",
@@ -522,6 +532,7 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
         "mem": "mem",
         "jobfs": "disk",
         "storage": "volumes",
+        "ngpus": "gpus",
     }
 
     # Check which resources are already specified (considering aliases)
@@ -592,6 +603,12 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
             if "volumes" not in specified_resources
             else None
         ),
+        "gpus": options.get("gpus")
+        or (
+            get_workflow_resource_config("gpus")
+            if "gpus" not in specified_resources
+            else None
+        ),
     }
 
     # Only create mapper if we have any resource values to process
@@ -614,6 +631,9 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
 
         if resource_values["volumes"]:
             mapper.add_storage(resource_values["volumes"])
+
+        if resource_values["gpus"]:
+            mapper.add_gpus(resource_values["gpus"])
 
         workflow_resources.extend(mapper.get_pbs_resources())
 
@@ -658,6 +678,7 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
         "cpus_explicit": cpus_explicit,  # Track for graceful adjustment
         "internet": options.get("internet", False),
         "notify": options.get("notify", False),  # Slack/Discord notifications
+        "gpu_type": options.get("gpu_type"),  # GPU type for queue selection
     }
 
     # Resolve and merge tags from --tag (multiple) and --tags (comma-separated string)
@@ -669,6 +690,11 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
     # If internet connectivity is required and no queue was explicitly requested,
     # trigger auto-selection so an internet-capable queue is chosen.
     if options.get("internet") and not options.get("queue"):
+        params["queue"] = "auto"
+
+    # If GPUs are requested and no queue was explicitly specified,
+    # trigger auto-selection so a GPU-capable queue is chosen.
+    if options.get("gpus") and not options.get("queue"):
         params["queue"] = "auto"
 
     # Process configuration using the existing config system

--- a/qxub/platforms/core.py
+++ b/qxub/platforms/core.py
@@ -96,6 +96,8 @@ class Queue:
     internet_connectivity: bool = False
     constraints: List[str] = field(default_factory=list)
     auto_min_cpus: Optional[int] = None
+    gpu_type: Optional[str] = None
+    cpus_per_gpu: Optional[int] = None
 
     def get_max_walltime(self, core_count: int) -> Optional[str]:
         """Get maximum walltime for given core count."""
@@ -421,6 +423,8 @@ class PlatformLoader:
             internet_connectivity=data.get("internet_connectivity", False),
             constraints=data.get("constraints", []),
             auto_min_cpus=data.get("auto_min_cpus"),
+            gpu_type=data.get("gpu_type"),
+            cpus_per_gpu=data.get("cpus_per_gpu"),
         )
 
     def get_platform(self, name: str) -> Optional[Platform]:

--- a/qxub/resources/mappers.py
+++ b/qxub/resources/mappers.py
@@ -102,6 +102,10 @@ class ResourceMapper:
         """Add CPU/cores specification."""
         self.pbs_resources.append(f"ncpus={cpus}")
 
+    def add_gpus(self, gpus: int) -> None:
+        """Add GPU count specification."""
+        self.pbs_resources.append(f"ngpus={gpus}")
+
     def add_disk(self, disk: Union[str, int], unit: str = "MB") -> None:
         """Add disk/jobfs specification."""
         if isinstance(disk, int):

--- a/qxub/resources/utils.py
+++ b/qxub/resources/utils.py
@@ -208,6 +208,15 @@ def evaluate_condition(condition: str, resources: dict) -> bool:
         # Get resource value
         if variable == "gpu_requested":
             resource_value = resources.get("gpus", 0)
+        elif variable == "gpu_type":
+            # String comparison for GPU type (e.g., "gpu_type == a100")
+            resource_value = resources.get("gpu_type", "")
+            if operator in ("==", "="):
+                return resource_value == value_str.lower()
+            elif operator == "!=":
+                return resource_value != value_str.lower()
+            else:
+                return False
         elif variable == "cpus":
             resource_value = resources.get("cpus", 1)
         elif variable == "memory":

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="qxub",
-    version="3.5.0",
+    version="3.5.1",
     author="John Reeves",
     author_email="j.reeves@garvan.org.au",
     description="Simplified job submission to HPC",


### PR DESCRIPTION
## Summary

Adds GPU support to qxub with two new CLI options and automatic queue selection for NCI Gadi GPU queues.

### New CLI options

- `--gpus INTEGER` — Number of GPUs to request (maps to PBS `ngpus` resource)
- `--gpu-type [v100|a100]` — GPU type, selects the appropriate queue automatically

### Auto queue selection

When `--gpus` is specified without an explicit `--queue`, queue is automatically set to `auto` and resolved based on the platform definition:

| GPU type | Queue selected | GPUs/node | CPUs/GPU | SU rate |
|----------|---------------|-----------|----------|---------|
| A100     | dgxa100       | 8         | 16       | 4.5     |
| V100 (default) | gpuvolta | 4        | 12       | 3.0     |

### Platform definition updates (`nci_gadi.yaml`)

- Added `dgxa100` queue (A100 GPUs) with correct limits
- Added `megamembw` queue
- Added `gpu_type` and `cpus_per_gpu` fields to GPU queues
- Fixed `megamem` SU billing rate (was 1.25, now 5.0)
- Added GPU-aware auto-selection rules

### Files changed

- `qxub/exec_cli.py` — New `--gpus` and `--gpu-type` click options
- `qxub/platforms/core.py` — `gpu_type` and `cpus_per_gpu` fields on Queue dataclass
- `qxub/resources/mappers.py` — `add_gpus()` method on ResourceMapper
- `qxub/resources/utils.py` — String comparison support in `evaluate_condition()`
- `qxub/config/handler.py` — Fixed PlatformLoader import, added gpu_type to requirements
- `docs/platforms/nci_gadi.yaml` — Updated platform definition
- `qxub/__init__.py`, `setup.py` — Version bump to 3.5.1