### PR TITLE
docs: add --gpus and --gpu-type to README, examples, platform config, and aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ qxub exec --resources mem=16GB,ncpus=8,walltime=2:00:00 --env myenv -- python sc
 qxub exec --queue auto --mem 1200GB --env myenv -- python big_job.py    # → megamem (58% cheaper!)
 qxub exec --queue auto --cpus 5000 --env myenv -- python parallel.py    # → normalsr
 
+# GPU jobs - queue and CPUs are set automatically
+qxub exec --gpus 1 --env pytorch -- python train.py                     # → gpuvolta, 12 CPUs
+qxub exec --gpus 4 --gpu-type a100 --env pytorch -- python train.py     # → dgxa100, 64 CPUs
+
 # Preview without running
 qxub exec --dry --env myenv -- python script.py
 
@@ -73,6 +77,8 @@ qxub exec --shortcut python -- script.py
 | `--cpus` / `--threads` | CPU cores/threads (workflow-friendly, default: configured) | `--cpus 8` or `--threads 4` |
 | `--runtime` / `--time` | Walltime limit (workflow-friendly, default: configured) | `--runtime 2h30m` or `--time 1h` |
 | `--disk` / `--jobfs` | Local disk requirement (workflow-friendly, default: configured) | `--disk 100GB` or `--jobfs 50GB` |
+| `--gpus` | Number of GPUs (auto-selects queue and CPUs) | `--gpus 1` or `--gpus 4` |
+| `--gpu-type` | GPU type: v100 (default) or a100 | `--gpu-type a100` |
 | `--volumes` / `--storage` | NCI storage volumes to mount (default: configured) | `--volumes gdata/a56` or `--storage gdata/a56+scratch/a56` |
 | `--var` | Set environment variable in job (repeatable) | `--var FOO=bar --var BAZ=qux` |
 | `--vars` | Set multiple env vars (comma-separated) | `--vars "FOO=bar,BAZ=qux"` |

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -6,7 +6,7 @@ Create shortcuts for common workflows.
 
 ```bash
 # Create an alias
-qxub config alias set gpu --env pytorch --queue auto -l ngpus=1 -l ncpus=12
+qxub config alias set gpu --env pytorch --gpus 1
 
 # Use the alias
 qxub alias gpu -- python train.py
@@ -30,7 +30,7 @@ qxub alias NAME [-- COMMAND]            # Execute alias
 
 ```bash
 # GPU training workflow
-qxub config alias set train --env pytorch --queue auto -l ngpus=1 -l ncpus=12 --name "training-{timestamp}"
+qxub config alias set train --env pytorch --gpus 1 --name "training-{timestamp}"
 
 # Big memory analysis
 qxub config alias set bigmem --env pandas -l mem=256GB --queue hugemem
@@ -48,7 +48,7 @@ qxub alias test -- python test_script.py
 
 ```bash
 # Create alias without command
-qxub config alias set gpu --env pytorch --queue auto -l ngpus=1
+qxub config alias set gpu --env pytorch --gpus 1
 
 # Use with different commands
 qxub alias gpu -- python train.py

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -92,8 +92,15 @@ qxub exec --mem 4GB --cpus 2 --time 30m --env base -- python quick_analysis.py
 qxub exec --mem 64GB --cpus 16 --time 4h --disk 200GB --volumes gdata/a56 --env pytorch -- python training.py
 qxub exec --mem 1TB --cpus 48 --time 12h --volumes gdata/a56+scratch/a56 --env bioinformatics -- ./genome_assembly.sh
 
-# GPU jobs with workflow-friendly resources
-qxub exec --mem 32GB --cpus 12 --time 8h --volumes gdata/a56+gdata/px14 --resources ngpus=1 --env pytorch -- python train_model.py
+# GPU jobs — queue and CPUs are set automatically from the platform definition
+qxub exec --gpus 1 --mem 32GB --time 8h --env pytorch -- python train_model.py
+# → gpuvolta queue, ncpus=12 (12 cpus_per_gpu × 1 GPU)
+
+qxub exec --gpus 4 --gpu-type a100 --mem 128GB --time 24h --env pytorch -- python large_training.py
+# → dgxa100 queue, ncpus=64 (16 cpus_per_gpu × 4 GPUs)
+
+# Override auto-calculated CPUs if needed
+qxub exec --gpus 1 --cpus 24 --mem 32GB --env pytorch -- python train_model.py
 
 # Perfect for Snakemake and other workflow engines
 snakemake --cluster "qxub exec --mem {resources.mem_gb}GB --cpus {threads} --time {resources.runtime}h --volumes {resources.storage} --"

--- a/docs/platform_configuration.md
+++ b/docs/platform_configuration.md
@@ -27,9 +27,12 @@ qxub --queue auto -l mem=300GB --env myenv -- python memory_job.py
 qxub --queue auto -l mem=1200GB --env myenv -- python huge_job.py
 # → Selects 'megamem' queue (1.25 SU/CPU·hr) - 58% cheaper than hugemem!
 
-# GPU jobs
-qxub --queue auto -l ngpus=1 -l ncpus=12 --env pytorch -- python train.py
-# → Selects 'gpuvolta' queue
+# GPU jobs — queue and CPUs set automatically
+qxub exec --gpus 1 --env pytorch -- python train.py
+# → Selects 'gpuvolta' queue, ncpus=12
+
+qxub exec --gpus 4 --gpu-type a100 --env pytorch -- python train.py
+# → Selects 'dgxa100' queue, ncpus=64
 
 # Large-scale jobs
 qxub --queue auto -l ncpus=5000 --env myenv -- python parallel_job.py
@@ -52,8 +55,10 @@ qxub automatically chooses the most cost-effective queue based on your requireme
 - **≤48 CPUs**: `normal` (2.0 SU/CPU·hr) - Default queue
 - **≤3200 CPUs**: `normalsl` (1.5 SU/CPU·hr) - Balanced option
 
-### Special Cases
-- **GPU required**: `gpuvolta` (3.0 SU/CPU·hr) - GPU compute
+### GPU Selection
+- **`--gpus N`**: Selects `gpuvolta` (V100, 3.0 SU/CPU·hr, 12 CPUs/GPU)
+- **`--gpus N --gpu-type a100`**: Selects `dgxa100` (A100, 4.5 SU/CPU·hr, 16 CPUs/GPU)
+- CPUs are auto-calculated: `ncpus = gpus × cpus_per_gpu`
 
 ## Cost Savings Example
 
@@ -85,7 +90,8 @@ Some queues have minimum requirements enforced by PBS:
 | `hugemembw` | High-memory | 1.25 | 1,020GB | 140 | Cost-effective high memory |
 | `hugemem` | High-memory | 3.0 | 1,470GB | 192 | High memory |
 | `megamem` | Mega-memory | 1.25 | 2,990GB | 96 | Extreme memory (best value) |
-| `gpuvolta` | GPU | 3.0 | 382GB | 960 | GPU compute |
+| `gpuvolta` | GPU (V100) | 3.0 | 382GB | 48 | V100 GPU compute (4 GPUs/node, 12 CPUs/GPU) |
+| `dgxa100` | GPU (A100) | 4.5 | 2,000GB | 128 | A100 GPU compute (8 GPUs/node, 16 CPUs/GPU) |
 | `copyq` | Data | 2.0 | 190GB | 1 | Data operations |
 
 ````


### PR DESCRIPTION
Documents the `--gpus` and `--gpu-type` options added in v3.5.1 (#80, #81).

### Updated files
- **README.md** — Options table + quick-start GPU example
- **docs/examples.md** — GPU examples showing auto-CPU calculation
- **docs/platform_configuration.md** — GPU selection rules, dgxa100 in queue table
- **docs/aliases.md** — Alias examples now use `--gpus` instead of raw `-l ngpus=1 -l ncpus=12`