### PR TITLE
feat: make --gpu-type data-driven from platform definitions

### DIFF
--- a/qxub/config/handler.py
+++ b/qxub/config/handler.py
@@ -6,6 +6,8 @@ logger = logging.getLogger(__name__)
 import os
 from pathlib import Path
 
+import click
+
 
 def _get_default_output_dir():
     """Get appropriate output directory that works across login and compute nodes."""
@@ -202,7 +204,24 @@ def select_auto_queue(params):
 
         # Add GPU type for queue selection if specified
         if params.get("gpu_type"):
-            requirements["gpu_type"] = params["gpu_type"].lower()
+            gpu_type = params["gpu_type"].lower()
+            requirements["gpu_type"] = gpu_type
+
+            # Validate gpu_type against platform definitions
+            valid_gpu_types = set()
+            for platform_name in platform_names:
+                platform = loader.get_platform(platform_name)
+                if not platform:
+                    continue
+                for q in platform.queues.values():
+                    if q.gpu_type:
+                        valid_gpu_types.add(q.gpu_type.lower())
+            if valid_gpu_types and gpu_type not in valid_gpu_types:
+                sorted_types = sorted(valid_gpu_types)
+                raise click.ClickException(
+                    f"Unknown GPU type '{gpu_type}'. "
+                    f"Available types: {', '.join(sorted_types)}"
+                )
 
         # Try to find best queue from any platform
         best_queue = None
@@ -254,6 +273,8 @@ def select_auto_queue(params):
             "Platform system not available for auto queue selection, using 'normal'"
         )
         params["queue"] = "normal"
+    except click.ClickException:
+        raise
     except Exception as e:
         logger.warning("Auto queue selection failed: %s, using 'normal'", e)
         params["queue"] = "normal"

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -83,8 +83,8 @@ def _get_shortcut_context_description(definition: dict) -> str:
 )
 @click.option(
     "--gpu-type",
-    type=click.Choice(["v100", "a100"], case_sensitive=False),
-    help="GPU type to request (v100=gpuvolta, a100=dgxa100). Used with --gpus for queue selection.",
+    type=str,
+    help="GPU type for queue selection (e.g. v100, a100). Valid types are defined by the platform.",
 )
 @click.option(
     "--volumes",


### PR DESCRIPTION
Removes the hardcoded `click.Choice(["v100", "a100"])` from `--gpu-type` and replaces it with a free-text string validated at runtime against platform YAML queue definitions.

**Before:** Adding a new GPU type (e.g. `h100`) required a code change to `exec_cli.py`.

**After:** Just add a queue with `gpu_type: h100` to the platform YAML — no code change needed.

### Changes

- **`qxub/exec_cli.py`**: `--gpu-type` changed from `click.Choice` to `type=str`
- **`qxub/config/handler.py`**:
  - Validates `gpu_type` against all `gpu_type` fields in loaded platform queue definitions
  - Raises `click.ClickException` with list of available types if invalid
  - Re-raises `ClickException` past the broad `except Exception` handler

### Error example
```
$ qxub exec --gpus 1 --gpu-type h200 --env pytorch -- python train.py
Error: Unknown GPU type 'h200'. Available types: a100, v100
```