### PR TITLE
feat: default job name to {cmd}-{date}-{time} when not specified

### DIFF
--- a/qxub/config/handler.py
+++ b/qxub/config/handler.py
@@ -51,6 +51,19 @@ def _sanitize_job_name(name):
     return sanitized
 
 
+def _default_job_name(command):
+    """Derive a default job name from the command: {cmd}-{date}-{time}."""
+    from datetime import datetime
+
+    cmd_word = "qx"
+    if command:
+        first = command[0] if isinstance(command, (list, tuple)) else command.split()[0]
+        cmd_word = Path(first).name or "qx"
+
+    now = datetime.now()
+    return f"{cmd_word}-{now.strftime('%Y%m%d')}-{now.strftime('%H%M%S')}"
+
+
 def apply_config_defaults(params, config_manager):
     """Apply configuration defaults to CLI parameters."""
     defaults = config_manager.get_defaults()
@@ -65,7 +78,11 @@ def apply_config_defaults(params, config_manager):
     if params["queue"] is None:
         params["queue"] = defaults.get("queue", "normal")
     if params["name"] is None:
-        params["name"] = defaults.get("name", "qt")
+        configured_name = defaults.get("name")
+        if configured_name:
+            params["name"] = configured_name
+        else:
+            params["name"] = _default_job_name(params.get("command"))
     if params["project"] is None:
         params["project"] = defaults.get("project", os.getenv("PROJECT"))
     if not params["resources"]:  # Empty tuple means no resources provided

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -52,7 +52,7 @@ def _get_shortcut_context_description(definition: dict) -> str:
 )
 @click.option("-q", "--queue", help="PBS queue name (default: configured or normal)")
 @click.option(
-    "-N", "--name", help="PBS job name (default: configured or qx-{timestamp})"
+    "-N", "--name", help="PBS job name (default: configured or {cmd}-{date}-{time})"
 )
 # Workflow-friendly resource options
 @click.option(
@@ -638,6 +638,7 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
 
     # Extract PBS-specific options for processing
     params = {
+        "command": command,
         "resources": tuple(all_resources),  # Use merged resources
         "queue": options["queue"],
         "name": options["name"],

--- a/qxub/execution/submit.py
+++ b/qxub/execution/submit.py
@@ -196,6 +196,7 @@ def submit_job(
     # Build params dict (mimics what exec_cli constructs)
     # ------------------------------------------------------------------
     params: Dict[str, Any] = {
+        "command": cmd_parts,
         "resources": tuple(pbs_resources),
         "queue": queue,
         "name": name,


### PR DESCRIPTION
When no job name is provided via `-N`/`--name` and no default is configured, derive the name from the first word of the command string plus the current date and time.

**Before:** hardcoded fallback `qt`
**After:** `{cmd}-{date}-{time}`, e.g. `dvc-20260411-122341`

### Examples
| Command | Default job name |
|---------|-----------------|
| `qx --env dvc3 -- dvc version` | `dvc-20260411-122341` |
| `qx -- python script.py` | `python-20260411-122341` |
| `qx -- /usr/bin/some_tool --flag` | `some_tool-20260411-122341` |

If a `name` is set in the user's config, that still takes priority. The new default only applies when neither CLI nor config provides a name.

### Changes
- **qxub/config/handler.py**: Added `_default_job_name()` function; updated `apply_config_defaults()` to use it as fallback
- **qxub/exec_cli.py**: Pass `command` tuple into params dict; updated help text
- **qxub/execution/submit.py**: Pass `command` tuple into params dict