### PR TITLE
feat: align qxet options with qx, fix list builtin shadowing

### DIFF
--- a/qxub/config_cli.py
+++ b/qxub/config_cli.py
@@ -960,9 +960,47 @@ def shortcut_config():
 @click.option("-q", "--queue", help="PBS queue name")
 @click.option("-N", "--name", help="PBS job name")
 @click.option("-P", "--project", help="PBS project code")
+@click.option("--gpus", type=int, help="Number of GPUs (workflow-friendly)")
+@click.option(
+    "--gpu-type", type=str, help="GPU type for queue selection (e.g. v100, a100)"
+)
 @click.option("--template", help="Job script template")
 @click.option("--pre", help="Command to run before main command")
 @click.option("--post", help="Command to run after main command")
+@click.option(
+    "--var",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Environment variable to set in the job (can be used multiple times)",
+)
+@click.option(
+    "--vars",
+    default=None,
+    metavar="VAR_STRING",
+    help='Comma-separated environment variables, e.g. --vars "FOO=bar,BAZ=qux"',
+)
+@click.option(
+    "--tag",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Tag for this shortcut (can be used multiple times)",
+)
+@click.option(
+    "--tags",
+    default=None,
+    metavar="TAG_STRING",
+    help='Comma-separated tags, e.g. --tags "workflow=brca,rule=align"',
+)
+@click.option(
+    "--internet",
+    is_flag=True,
+    help="Require internet connectivity (selects an internet-capable queue)",
+)
+@click.option("--execdir", help="Execution directory for the job")
+@click.option("--log-dir", help="Log directory for job output files")
+@click.option("--email", help="Email address for PBS notifications")
+@click.option("--email-opts", help="PBS email options (e.g., 'abe')")
+@click.option("--array", help="Job array specification (e.g., '1-10' or '1-100:2')")
 @click.option("--cmd", help="Default command to execute (can be overridden)")
 @click.option(
     "--user", "user_config", is_flag=True, help="Set shortcut in user config (default)"
@@ -1069,6 +1107,10 @@ def set_shortcut(command_prefix: str, user_config: bool, system: bool, **options
     if options["resources"]:
         resources_list.append(options["resources"])
 
+    # GPU options
+    if options.get("gpus"):
+        resources_list.append(f"ngpus={options['gpus']}")
+
     # Store resources if any were provided
     if resources_list:
         definition["resources"] = resources_list
@@ -1080,6 +1122,10 @@ def set_shortcut(command_prefix: str, user_config: bool, system: bool, **options
     if options["project"]:
         definition["project"] = options["project"]
 
+    # GPU type (for queue selection, separate from resource spec)
+    if options.get("gpu_type"):
+        definition["gpu_type"] = options["gpu_type"]
+
     # Job script options
     if options["template"]:
         definition["template"] = options["template"]
@@ -1087,6 +1133,42 @@ def set_shortcut(command_prefix: str, user_config: bool, system: bool, **options
         definition["pre"] = options["pre"]
     if options["post"]:
         definition["post"] = options["post"]
+
+    # Environment variables
+    env_vars = list(options.get("var") or [])
+    vars_str = options.get("vars") or ""
+    env_vars += [v.strip() for v in vars_str.split(",") if v.strip()]
+    if env_vars:
+        definition["vars"] = env_vars
+
+    # Tags
+    tags = list(options.get("tag") or [])
+    tags_str = options.get("tags") or ""
+    tags += [t.strip() for t in tags_str.split(",") if t.strip()]
+    if tags:
+        definition["tags"] = tags
+
+    # Internet requirement
+    if options.get("internet"):
+        definition["internet"] = True
+
+    # Execution directory
+    if options.get("execdir"):
+        definition["execdir"] = options["execdir"]
+
+    # Log directory
+    if options.get("log_dir"):
+        definition["log_dir"] = options["log_dir"]
+
+    # Email notifications
+    if options.get("email"):
+        definition["email"] = options["email"]
+    if options.get("email_opts"):
+        definition["email_opts"] = options["email_opts"]
+
+    # Job arrays
+    if options.get("array"):
+        definition["array"] = options["array"]
 
     # Command and metadata
     if options["cmd"]:
@@ -1153,11 +1235,11 @@ def set_shortcut(command_prefix: str, user_config: bool, system: bool, **options
     click.echo(f"💡 Or explicit: qxub exec --shortcut '{command_prefix}' -- [command]")
 
 
-@shortcut_config.command()
+@shortcut_config.command(name="list")
 @click.option(
     "--show-origin", is_flag=True, help="Show origin (user/system) for each shortcut"
 )
-def list(show_origin: bool):
+def list_shortcuts(show_origin: bool):
     """List all available shortcuts."""
     from .shortcut_manager import shortcut_manager
 

--- a/qxub/exec_cli.py
+++ b/qxub/exec_cli.py
@@ -416,6 +416,28 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
                 options["post"] = value
             elif key == "bind" and not options["bind"]:
                 options["bind"] = value
+            elif key == "name" and not options["name"]:
+                options["name"] = value
+            elif key == "internet" and not options.get("internet"):
+                options["internet"] = value
+            elif key == "gpus" and not options.get("gpus"):
+                options["gpus"] = value
+            elif key == "gpu_type" and not options.get("gpu_type"):
+                options["gpu_type"] = value
+            elif key == "vars" and not options.get("var") and not options.get("vars"):
+                options["var"] = tuple(value) if isinstance(value, list) else (value,)
+            elif key == "tags" and not options.get("tag") and not options.get("tags"):
+                options["tag"] = tuple(value) if isinstance(value, list) else (value,)
+            elif key == "execdir" and not options.get("execdir"):
+                options["execdir"] = value
+            elif key == "log_dir" and not options.get("log_dir"):
+                options["log_dir"] = value
+            elif key == "email" and not options.get("email"):
+                options["email"] = value
+            elif key == "email_opts" and not options.get("email_opts"):
+                options["email_opts"] = value
+            elif key == "array" and not options.get("array"):
+                options["array"] = value
 
         click.echo(f"🎯 Using shortcut '{shortcut}'")
     elif not any(
@@ -458,6 +480,44 @@ def exec_cli(ctx, command, cmd, shortcut, alias, verbose, config, **options):
                         options["resources"] = (value,)
                 elif key == "project" and not options["project"]:
                     options["project"] = value
+                elif key == "template" and not options.get("template"):
+                    options["template"] = value
+                elif key == "pre" and not options.get("pre"):
+                    options["pre"] = value
+                elif key == "post" and not options.get("post"):
+                    options["post"] = value
+                elif key == "bind" and not options.get("bind"):
+                    options["bind"] = value
+                elif key == "name" and not options["name"]:
+                    options["name"] = value
+                elif key == "internet" and not options.get("internet"):
+                    options["internet"] = value
+                elif key == "gpus" and not options.get("gpus"):
+                    options["gpus"] = value
+                elif key == "gpu_type" and not options.get("gpu_type"):
+                    options["gpu_type"] = value
+                elif (
+                    key == "vars" and not options.get("var") and not options.get("vars")
+                ):
+                    options["var"] = (
+                        tuple(value) if isinstance(value, list) else (value,)
+                    )
+                elif (
+                    key == "tags" and not options.get("tag") and not options.get("tags")
+                ):
+                    options["tag"] = (
+                        tuple(value) if isinstance(value, list) else (value,)
+                    )
+                elif key == "execdir" and not options.get("execdir"):
+                    options["execdir"] = value
+                elif key == "log_dir" and not options.get("log_dir"):
+                    options["log_dir"] = value
+                elif key == "email" and not options.get("email"):
+                    options["email"] = value
+                elif key == "email_opts" and not options.get("email_opts"):
+                    options["email_opts"] = value
+                elif key == "array" and not options.get("array"):
+                    options["array"] = value
 
             # For shortcuts, keep the full original command (don't strip the prefix)
             # The shortcut defines the execution context, not the command itself

--- a/skills/navigate-codebase/SKILL.md
+++ b/skills/navigate-codebase/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: navigate-codebase
+description: >
+  Navigate the qxub codebase to find the right module quickly.
+  Use this when asked to implement, modify, or debug any qxub/qx/qxet command,
+  or when you need to know where a feature lives before reading or editing files.
+  Also use this when adding a new module, CLI command, or exported function —
+  to look up where it fits and to update modules.json to reflect the change.
+---
+
+The structured module map for this codebase lives in `modules.json` alongside
+this file. Query it with `jq` before reading source files.
+
+> Note: `jq` is available in the `qxub` conda env and the base conda env on
+> this system. If unavailable, fall back to reading `modules.json` directly.
+
+## Useful queries
+
+```sh
+# Find the module(s) for a CLI command (e.g. "exec", "config", "status")
+jq '.commands[] | select(.command | contains("exec"))' modules.json
+
+# Find a module by keyword in its description or exports
+jq '.modules[] | select(.description | ascii_downcase | contains("scheduler"))' modules.json
+jq '.modules[] | select(.exports[]? | contains("ResourceMapper"))' modules.json
+
+# List all top-level CLI commands
+jq -r '.commands[].command' modules.json
+
+# List all entry-point aliases
+jq -r '.commands[] | select(.alias) | "\(.alias) → \(.command)"' modules.json
+
+# Find which module handles shortcuts
+jq '.modules[] | select(.exports[]? | contains("ShortcutManager"))' modules.json
+```
+
+Run these from the skill directory, or pass the full path to `modules.json`.
+
+## Key structural facts (not in the JSON)
+
+- **CLI entry point**: `qxub/cli.py` defines the main Click group and
+  registers all subcommands. Each subcommand delegates to its own `*_cli.py`
+  module.
+- **Execution flow**: `exec_cli.py` → `execution/mode.py` (local vs remote) →
+  `execution/executors.py` (build job script) → `core/scheduler.py` (qsub) →
+  `queue/db.py` (record virtual ID) → `core/scheduler.py` (monitor).
+- **Configuration precedence**: Override > Test > Local > Project > User >
+  System > Defaults. Managed by `config/manager.py`.
+- **Standalone aliases**: `qx` → `qxub exec`, `qxet` → `qxub config shortcut set`,
+  `qxtat` → `qxub status`, `qxi` → interactive session. Defined in
+  `config/aliases.py` and registered as entry points in `setup.py`.
+- **PBS interaction**: Always via `subprocess.run(['qsub', …])` /
+  `subprocess.run(['qdel', …])` in `core/scheduler.py` — never direct API.
+- **Template system**: Job script templates in `qxub/jobscripts/*.pbs`.
+  Selected by execution context (conda, module, singularity, default).
+- **Lazy imports**: `__init__.py` uses `__getattr__` to defer heavy CLI
+  imports until actually invoked.
+- **Platform definitions**: YAML files loaded by `platforms/loader.py`.
+  Auto-detection uses hostname matching.
+
+## Keeping `modules.json` up to date
+
+When you add a new module, CLI command, or significant exported function,
+add or update the relevant entry in `modules.json` as part of the same change.

--- a/skills/navigate-codebase/modules.json
+++ b/skills/navigate-codebase/modules.json
@@ -1,0 +1,356 @@
+{
+  "commands": [
+    {
+      "command": "qxub",
+      "module": "qxub/cli.py",
+      "description": "Main CLI group – dispatches to all subcommands"
+    },
+    {
+      "command": "qxub exec",
+      "alias": "qx",
+      "module": "qxub/exec_cli.py",
+      "description": "Submit and monitor a PBS job (conda, module, singularity, or default context)"
+    },
+    {
+      "command": "qxub interactive",
+      "alias": "qxi",
+      "module": "qxub/interactive_cli.py",
+      "description": "Launch an interactive PBS session"
+    },
+    {
+      "command": "qxub config",
+      "module": "qxub/config_cli.py",
+      "description": "Configuration management (get/set, shortcuts, aliases, files, validate)"
+    },
+    {
+      "command": "qxub config shortcut set",
+      "alias": "qxet",
+      "module": "qxub/config_cli.py",
+      "description": "Create or update a reusable execution shortcut"
+    },
+    {
+      "command": "qxub config shortcut list",
+      "module": "qxub/config_cli.py",
+      "description": "List all configured shortcuts"
+    },
+    {
+      "command": "qxub config shortcut show",
+      "module": "qxub/config_cli.py",
+      "description": "Show details of a specific shortcut"
+    },
+    {
+      "command": "qxub config shortcut delete",
+      "module": "qxub/config_cli.py",
+      "description": "Delete a shortcut"
+    },
+    {
+      "command": "qxub cancel",
+      "module": "qxub/cancel_cli.py",
+      "description": "Cancel PBS jobs by ID or name pattern"
+    },
+    {
+      "command": "qxub status",
+      "alias": "qxtat",
+      "module": "qxub/status_cli.py",
+      "description": "Query and display job status"
+    },
+    {
+      "command": "qxub history",
+      "module": "qxub/history_cli.py",
+      "description": "View computational recipes and execution records"
+    },
+    {
+      "command": "qxub monitor",
+      "module": "qxub/monitor_cli.py",
+      "description": "Monitor multiple PBS jobs simultaneously"
+    },
+    {
+      "command": "qxub notify",
+      "module": "qxub/notify_cli.py",
+      "description": "Send Slack/Discord notifications on job completion"
+    },
+    {
+      "command": "qxub replay",
+      "module": "qxub/replay_cli.py",
+      "description": "Replay recorded interactive session transcripts"
+    },
+    {
+      "command": "qxub resources",
+      "module": "qxub/resources_cli.py",
+      "description": "View resource usage and efficiency statistics"
+    },
+    {
+      "command": "qxub platform",
+      "module": "qxub/platform_cli.py",
+      "description": "Platform discovery, info, and queue listing"
+    },
+    {
+      "command": "qxub select-queue",
+      "module": "qxub/platforms/cli.py",
+      "description": "Select best queue for given resources"
+    },
+    {
+      "command": "qxub validate",
+      "module": "qxub/platforms/cli.py",
+      "description": "Validate resource specifications against platform"
+    },
+    {
+      "command": "qxub estimate",
+      "module": "qxub/platforms/cli.py",
+      "description": "Estimate job cost in service units"
+    },
+    {
+      "command": "qxub alias",
+      "module": "qxub/alias_cli.py",
+      "description": "Legacy alias management (deprecated; use config alias)"
+    }
+  ],
+
+  "modules": [
+    {
+      "path": "qxub/__init__.py",
+      "description": "Package root – version, lazy CLI import, public API re-exports",
+      "exports": ["__version__", "qxub"]
+    },
+    {
+      "path": "qxub/cli.py",
+      "description": "Main Click group; registers all subcommands",
+      "exports": ["qxub"]
+    },
+    {
+      "path": "qxub/exec_cli.py",
+      "description": "Job execution command – parses ~45 options, resolves shortcuts, dispatches to execution contexts",
+      "exports": ["exec_cli"]
+    },
+    {
+      "path": "qxub/interactive_cli.py",
+      "description": "Interactive PBS session launcher with shell and env support",
+      "exports": ["interactive_cli", "qxi_main"]
+    },
+    {
+      "path": "qxub/config_cli.py",
+      "description": "Configuration management CLI – get/set/list/files/validate plus shortcut and alias subgroups",
+      "exports": ["config_cli", "shortcut_config", "set_shortcut"]
+    },
+    {
+      "path": "qxub/cancel_cli.py",
+      "description": "Cancel jobs by ID, name, or pattern with resource-tracker integration",
+      "exports": ["cancel_cli"]
+    },
+    {
+      "path": "qxub/status_cli.py",
+      "description": "Job status queries – list recent, show details, summary",
+      "exports": ["status_cli", "StatusTracker"]
+    },
+    {
+      "path": "qxub/history_cli.py",
+      "description": "History CLI – recipes, executions, latest, out, err, log",
+      "exports": ["history"]
+    },
+    {
+      "path": "qxub/monitor_cli.py",
+      "description": "Multi-job monitoring with real-time status display",
+      "exports": ["monitor_cli", "MultiJobMonitor"]
+    },
+    {
+      "path": "qxub/notify_cli.py",
+      "description": "Notification CLI – send and test Slack/Discord hooks",
+      "exports": ["notify_cli"]
+    },
+    {
+      "path": "qxub/replay_cli.py",
+      "description": "Replay interactive session recordings with timing",
+      "exports": ["replay_cli"]
+    },
+    {
+      "path": "qxub/resources_cli.py",
+      "description": "Resource-tracking CLI – list, show, CSV export, tag/date filtering",
+      "exports": ["resources"]
+    },
+    {
+      "path": "qxub/platform_cli.py",
+      "description": "Platform management CLI – list, info, queues",
+      "exports": ["platform_cli"]
+    },
+    {
+      "path": "qxub/alias_cli.py",
+      "description": "Legacy alias CLI (deprecated; code moved to config_cli)",
+      "exports": ["alias_cli"]
+    },
+    {
+      "path": "qxub/shortcut_manager.py",
+      "description": "Shortcut resolution – loads system/user shortcuts JSON, finds longest-match",
+      "exports": ["ShortcutManager"]
+    },
+    {
+      "path": "qxub/execution_context.py",
+      "description": "Legacy execution context module (functionality moved to execution/)",
+      "exports": []
+    },
+
+    {
+      "path": "qxub/config/manager.py",
+      "description": "Hierarchical config loading/merging (Override > Test > Local > Project > User > System > Defaults)",
+      "exports": ["ConfigManager"]
+    },
+    {
+      "path": "qxub/config/handler.py",
+      "description": "Job option processing – apply defaults, sanitize job name, resolve output dir",
+      "exports": ["process_job_options", "apply_config_defaults", "_default_job_name", "_sanitize_job_name"]
+    },
+    {
+      "path": "qxub/config/shortcuts.py",
+      "description": "Shortcut loading/resolution with system/user JSON files",
+      "exports": ["ShortcutManager"]
+    },
+    {
+      "path": "qxub/config/aliases.py",
+      "description": "Standalone entry-point aliases: qx_main, qxet_main, qxtat_main",
+      "exports": ["qx_main", "qxet_main", "qxtat_main"]
+    },
+
+    {
+      "path": "qxub/execution/__init__.py",
+      "description": "Execution package public API – re-exports from core, executors, context, mode, submit",
+      "exports": [
+        "submit_and_monitor_job", "validate_execution_context",
+        "build_submission_variables", "expand_submission_variables",
+        "execute_conda", "execute_module", "execute_singularity", "execute_default",
+        "ExecutionContext", "execute_unified",
+        "ExecutionMode", "get_execution_mode",
+        "submit_job", "SubmitResult", "QsubError"
+      ]
+    },
+    {
+      "path": "qxub/execution/core.py",
+      "description": "Core submission – variable expansion, smart-quote processing, submit_and_monitor_job",
+      "exports": ["submit_and_monitor_job", "expand_submission_variables", "build_submission_variables", "validate_execution_context"]
+    },
+    {
+      "path": "qxub/execution/context.py",
+      "description": "Unified ExecutionContext dataclass – validate, get template, build submission vars",
+      "exports": ["ExecutionContext", "execute_unified", "create_conda_context", "create_module_context", "create_singularity_context", "create_default_context"]
+    },
+    {
+      "path": "qxub/execution/executors.py",
+      "description": "Context-specific executors – build job scripts and submit for conda/module/singularity/default",
+      "exports": ["execute_conda", "execute_module", "execute_singularity", "execute_default"]
+    },
+    {
+      "path": "qxub/execution/mode.py",
+      "description": "Detect LOCAL vs REMOTE vs REMOTE_DELEGATED execution mode from platform config",
+      "exports": ["ExecutionMode", "get_execution_mode", "get_remote_config", "validate_remote_config"]
+    },
+    {
+      "path": "qxub/execution/submit.py",
+      "description": "Programmatic job submission API (no CLI dependency)",
+      "exports": ["submit_job", "SubmitResult"]
+    },
+
+    {
+      "path": "qxub/core/scheduler.py",
+      "description": "PBS interaction – qsub, qdel, monitor_job_single_thread, job_status_from_files, resource extraction",
+      "exports": ["qsub", "qdel", "monitor_job_single_thread", "job_status_from_files", "get_job_resource_data", "QsubError", "SimpleSpinner"]
+    },
+    {
+      "path": "qxub/core/templates.py",
+      "description": "Job script template loading – get_template, get_conda_template, etc.",
+      "exports": ["get_template", "get_conda_template", "get_module_template"]
+    },
+
+    {
+      "path": "qxub/platforms/core.py",
+      "description": "Platform abstraction – Platform, Queue, QueueLimits, QueueSelector, detect_platform",
+      "exports": ["Platform", "Queue", "QueueLimits", "QueueSelector", "detect_platform", "get_platform", "list_platforms", "select_best_queue"]
+    },
+    {
+      "path": "qxub/platforms/loader.py",
+      "description": "Load platform definitions from URL/file/search paths with caching",
+      "exports": ["PlatformLoader", "PlatformLoadError"]
+    },
+    {
+      "path": "qxub/platforms/cli.py",
+      "description": "Platform CLI subcommands – estimate_cmd, validate_cmd, select_queue_cmd",
+      "exports": ["estimate_cmd", "validate_cmd", "select_queue_cmd", "platform_cli"]
+    },
+
+    {
+      "path": "qxub/resources/parser.py",
+      "description": "Parse PBS resource formats – size_to_bytes, time_to_seconds, parse_exec_host, parse_joblog_resources",
+      "exports": ["size_to_bytes", "time_to_seconds", "parse_exec_host", "parse_exec_vnode", "parse_joblog_resources"]
+    },
+    {
+      "path": "qxub/resources/utils.py",
+      "description": "Resource utilities – parse/format memory and walltime, evaluate queue constraints",
+      "exports": ["parse_memory_size", "format_memory_size", "parse_walltime", "format_walltime"]
+    },
+    {
+      "path": "qxub/resources/mappers.py",
+      "description": "ResourceMapper – convert workflow formats to PBS (add_memory, add_runtime, add_cpus, add_jobfs, add_storage)",
+      "exports": ["ResourceMapper"]
+    },
+    {
+      "path": "qxub/resources/tracker.py",
+      "description": "SQLite-based job resource tracking and efficiency analysis",
+      "exports": ["ResourceTracker"]
+    },
+
+    {
+      "path": "qxub/queue/db.py",
+      "description": "SQLite queue DB – virtual IDs, job entries, status updates, bulk queries",
+      "exports": ["get_db_path", "init_db", "new_virtual_id", "create_queue_entry", "update_queue_entry", "resolve_virtual_id", "mark_running", "mark_complete"]
+    },
+
+    {
+      "path": "qxub/history/base.py",
+      "description": "History data structures and constants",
+      "exports": ["CommandHistoryLogger"]
+    },
+    {
+      "path": "qxub/history/manager.py",
+      "description": "Dual-log history system – recipes.yaml + executions.yaml",
+      "exports": ["HistoryManager"]
+    },
+
+    {
+      "path": "qxub/remote/platform_executor.py",
+      "description": "SSH-based remote job execution using platform config",
+      "exports": ["PlatformRemoteExecutor", "RemoteExecutionError"]
+    },
+    {
+      "path": "qxub/remote/command_builder.py",
+      "description": "Serialize qxub commands for SSH execution",
+      "exports": ["build_remote_command"]
+    },
+
+    {
+      "path": "qxub/notifications/slack.py",
+      "description": "Slack webhook notifier",
+      "exports": ["SlackNotifier"]
+    },
+    {
+      "path": "qxub/notifications/discord.py",
+      "description": "Discord webhook notifier",
+      "exports": ["DiscordNotifier"]
+    }
+  ],
+
+  "jobscript_templates": [
+    { "path": "qxub/jobscripts/qconda.pbs",  "context": "conda" },
+    { "path": "qxub/jobscripts/qmod.pbs",     "context": "module" },
+    { "path": "qxub/jobscripts/qsing.pbs",    "context": "singularity" },
+    { "path": "qxub/jobscripts/qdefault.pbs", "context": "default" }
+  ],
+
+  "platform_definitions": [
+    { "path": "qxub/platforms/gadi.yaml", "platform": "gadi" }
+  ],
+
+  "entry_points": {
+    "qxub":  "qxub.cli:qxub",
+    "qx":    "qxub.config.aliases:qx_main",
+    "qxet":  "qxub.config.aliases:qxet_main",
+    "qxtat": "qxub.config.aliases:qxtat_main",
+    "qxi":   "qxub.interactive_cli:qxi_main"
+  }
+}


### PR DESCRIPTION
## Summary

Bring `qxet` (`qxub config shortcut set`) into alignment with `qx` (`qxub exec`) for supported options, fix a critical `list` builtin shadowing bug, and add a navigate-codebase skill.

## Changes

### New `qxet` options (config_cli.py)
Options that were available in `qx` but missing from `qxet`:
- `--internet` — require internet connectivity
- `--gpus` / `--gpu-type` — GPU resources and queue selection
- `--var` / `--vars` — environment variables
- `--tag` / `--tags` — job tags
- `--execdir` — execution directory
- `--log-dir` — log directory
- `--email` / `--email-opts` — PBS email notifications
- `--array` — job array specification

### Shortcut apply logic (exec_cli.py)
Updated **both** shortcut apply blocks (explicit `--shortcut` and auto-match) to map all new shortcut fields to `exec` options.

### Bug fix: `list` builtin shadowing (config_cli.py)
**Root cause**: `@shortcut_config.command() def list(...)` at module scope shadowed Python's builtin `list()`. When `set_shortcut` called `list(options["mod"])`, it invoked the Click command instead of the Python list constructor, causing `qxet` to display the shortcut table instead of saving shortcuts.

**Fix**: Renamed `def list(...)` → `def list_shortcuts(...)` with `@shortcut_config.command(name="list")` to preserve the CLI command name while avoiding the name collision.

### Navigate-codebase skill
Added `skills/navigate-codebase/SKILL.md` and `modules.json` — a structured codebase map with jq-queryable module/command data for agent-assisted navigation.

## Testing
- `qxet "dvc pull" --env dvc3 --internet` → ✅ saves correctly
- `qxet "gpu-train" --env pytorch --gpus 1 --gpu-type v100 --vars "CUDA_VISIBLE_DEVICES=0" --tags "ml,training"` → ✅ all fields persisted
- `qxet "email-test" --env myenv --email "user@example.com" --email-opts "abe" --execdir "/scratch" --log-dir "/logs" --array "1-10"` → ✅ all fields persisted
- `qxub config shortcut list` → ✅ still works correctly
- Pre-commit checks (black, isort, trailing whitespace) → ✅ all pass