### PR TITLE
fix: use CorePlatformLoader for auto queue selection

### DIFF
--- a/qxub/__init__.py
+++ b/qxub/__init__.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "3.6.0"
+__version__ = "3.6.1"
 
 # Library-standard NullHandler: prevents "No handler found" warnings and
 # avoids triggering basicConfig() when qxub is used as a library.

--- a/qxub/config/handler.py
+++ b/qxub/config/handler.py
@@ -170,7 +170,7 @@ def select_auto_queue(params):
     try:
         from pathlib import Path
 
-        from ..platforms import PlatformLoader
+        from ..platforms import CorePlatformLoader as PlatformLoader
         from ..resources import parse_walltime  # noqa: F811
 
         # Check for QXUB_PLATFORM_PATHS environment variable

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="qxub",
-    version="3.6.0",
+    version="3.6.1",
     author="John Reeves",
     author_email="j.reeves@garvan.org.au",
     description="Simplified job submission to HPC",


### PR DESCRIPTION
## Problem

`select_auto_queue()` in `handler.py` was importing `PlatformLoader` from `..platforms`, which resolves to the URL/file definition loader (`qxub/platforms/loader.py`). This class handles downloading and caching platform YAML definitions — it has no `list_platforms()` or `get_platform()` methods.

The function needs the **platform registry** class from `qxub/platforms/core.py`, which provides platform discovery, `list_platforms()`, `get_platform()`, and queue selection.

This caused the error:
```
WARNING: Auto queue selection failed: 'PlatformLoader' object has no attribute 'list_platforms', using 'normal'
```

## Root Cause

Two classes named `PlatformLoader` exist in the codebase:
- `qxub/platforms/loader.py` → URL/file definition loader (exported as `PlatformLoader` in `__init__.py`)
- `qxub/platforms/core.py` → Platform registry with `list_platforms()`, `get_platform()`, `select_queue()` (exported as `CorePlatformLoader` in `__init__.py`)

The handler was importing the wrong one.

## Fix

Changed the import to use `CorePlatformLoader` (aliased as `PlatformLoader` locally to minimize code churn):

```python
from ..platforms import CorePlatformLoader as PlatformLoader
```

Both classes accept `search_paths` in their constructor, so the `QXUB_PLATFORM_PATHS` handling continues to work correctly.