### PR TITLE
feat: add audit header to all PBS job script templates

### DIFF
--- a/qxub/execution/context.py
+++ b/qxub/execution/context.py
@@ -8,6 +8,7 @@ and execute_default functions.
 
 import base64
 import logging
+import shutil
 
 logger = logging.getLogger(__name__)
 import os
@@ -100,13 +101,19 @@ class ExecutionContext:
         cmd_str = " ".join(command)
         cmd_b64 = base64.b64encode(cmd_str.encode("utf-8")).decode("ascii")
 
+        # Capture submitting host's qxub version and executable path
+        from .. import __version__ as qxub_version
+
+        qxub_exe = shutil.which("qxub") or "unknown"
+        submitting_host = os.uname().nodename
+
         # Base submission variables
         out = Path(ctx_obj["out"])
         err = Path(ctx_obj["err"])
         # Default to current working directory if execdir is None
         exec_dir = ctx_obj["execdir"] or os.getcwd()
         create_execdir = str(ctx_obj.get("create_execdir", False)).lower()
-        base_vars = f'cmd_b64="{cmd_b64}",cwd={exec_dir},out={out},err={err},quiet={str(ctx_obj["quiet"]).lower()},create_execdir={create_execdir}'
+        base_vars = f'cmd_b64="{cmd_b64}",cwd={exec_dir},out={out},err={err},quiet={str(ctx_obj["quiet"]).lower()},create_execdir={create_execdir},qxub_version={qxub_version},qxub_path={qxub_exe},qxub_submit_host={submitting_host}'
 
         # Context-specific variables
         if self.context_type == "conda":

--- a/qxub/jobscripts/qconda.pbs
+++ b/qxub/jobscripts/qconda.pbs
@@ -9,6 +9,9 @@
 # Logging
 echo "📁 Execution directory: $cwd"
 echo "🐍 Conda environment: $env"
+echo "🔖 qxub version: ${qxub_version:-unknown}"
+echo "📦 qxub path: ${qxub_path:-unknown}"
+echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
 
 # Decode base64 encoded commands
 if [ -n "$cmd_b64" ]; then

--- a/qxub/jobscripts/qconda_mod.pbs
+++ b/qxub/jobscripts/qconda_mod.pbs
@@ -10,6 +10,9 @@
 echo "📁 Execution directory: $cwd"
 echo "📦 Modules to load: $mods"
 echo "🐍 Conda environment: $env"
+echo "🔖 qxub version: ${qxub_version:-unknown}"
+echo "📦 qxub path: ${qxub_path:-unknown}"
+echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
 
 # Decode base64 encoded commands
 if [ -n "$cmd_b64" ]; then

--- a/qxub/jobscripts/qdefault.pbs
+++ b/qxub/jobscripts/qdefault.pbs
@@ -9,6 +9,9 @@
 # Logging
 echo "📁 Execution directory: $cwd"
 echo "🔧 Default execution (no environment activation)"
+echo "🔖 qxub version: ${qxub_version:-unknown}"
+echo "📦 qxub path: ${qxub_path:-unknown}"
+echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
 
 # Decode base64 encoded commands
 if [ -n "$cmd_b64" ]; then

--- a/qxub/jobscripts/qmod.pbs
+++ b/qxub/jobscripts/qmod.pbs
@@ -9,6 +9,9 @@
 # Logging
 echo "📁 Execution directory: $cwd"
 echo "📦 Modules to load: $mods"
+echo "🔖 qxub version: ${qxub_version:-unknown}"
+echo "📦 qxub path: ${qxub_path:-unknown}"
+echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
 
 # Create status directory for monitoring
 STATUS_DIR="${out%/*}/status"

--- a/qxub/jobscripts/qsing.pbs
+++ b/qxub/jobscripts/qsing.pbs
@@ -10,6 +10,9 @@
 echo "📁 Execution directory: $cwd"
 echo "📦 Singularity container: $sif_file"
 echo "⚙️  Singularity options: $sing_options"
+echo "🔖 qxub version: ${qxub_version:-unknown}"
+echo "📦 qxub path: ${qxub_path:-unknown}"
+echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
 
 # Create status directory for monitoring
 STATUS_DIR="${out%/*}/status"


### PR DESCRIPTION
## Summary

Every PBS job log now prints an audit header showing the qxub version, executable path, and submitting hostname at the top of the job log output — before any environment activation or command execution.

## Changes

### `qxub/execution/context.py`
- `build_submission_vars()` now captures and passes three new variables via `qsub -v`:
  - `qxub_version` — from `qxub.__version__` (e.g. `3.6.1`)
  - `qxub_path` — from `shutil.which("qxub")` (e.g. `/g/data/a56/conda/envs/usr/jr9959/qxub/bin/qxub`)
  - `qxub_submit_host` — from `os.uname().nodename` (e.g. `gadi-login-01.nci.org.au`)

### All 5 PBS templates (`qconda.pbs`, `qconda_mod.pbs`, `qdefault.pbs`, `qmod.pbs`, `qsing.pbs`)
- Added 3 echo lines in the `# Logging` block printing the audit variables with `${var:-unknown}` fallback

## Example job log output

```
📁 Execution directory: /scratch/a56/jr9959/project
🐍 Conda environment: pytorch
🔖 qxub version: 3.6.1
📦 qxub path: /g/data/a56/conda/envs/usr/jr9959/qxub/bin/qxub
🖥️  Submitted from: gadi-login-01.nci.org.au
💻 Command: python train.py
```

## Remote execution audit trail

For remote execution (CI → login node → compute node):
- `qxub_version` and `qxub_path` are captured on the **submitting host** (the login node that runs `qsub`)
- `qxub_submit_host` records which login node submitted the job
- This gives a reliable audit trail: the CI runner SSHs into a login node, which runs qxub, which captures its own version/path/hostname and passes them into the PBS job