### PR TITLE
fix: serialize all exec CLI options for remote execution

### DIFF
--- a/qxub/remote/command_builder.py
+++ b/qxub/remote/command_builder.py
@@ -99,6 +99,8 @@ def _add_cli_options(parts: List[str], options: Dict[str, Any]) -> None:
         parts.append("--quiet")
     if options.get("terse", False):
         parts.append("--terse")
+    if options.get("internet", False):
+        parts.append("--internet")
 
 
 def _add_pbs_options(parts: List[str], options: Dict[str, Any]) -> None:
@@ -143,6 +145,14 @@ def _add_workflow_options(parts: List[str], options: Dict[str, Any]) -> None:
     if options.get("volumes"):
         parts.extend(["--volumes", shlex.quote(str(options["volumes"]))])
 
+    # GPUs
+    if options.get("gpus"):
+        parts.extend(["--gpus", str(options["gpus"])])
+
+    # GPU type
+    if options.get("gpu_type"):
+        parts.extend(["--gpu-type", shlex.quote(str(options["gpu_type"]))])
+
 
 def _add_job_options(parts: List[str], options: Dict[str, Any]) -> None:
     """Add job configuration options to command parts."""
@@ -183,6 +193,32 @@ def _add_job_options(parts: List[str], options: Dict[str, Any]) -> None:
         parts.extend(["--pre", shlex.quote(str(options["pre"]))])
     if options.get("post"):
         parts.extend(["--post", shlex.quote(str(options["post"]))])
+
+    # Log directory override
+    if options.get("log_dir"):
+        parts.extend(["--log-dir", shlex.quote(str(options["log_dir"]))])
+
+    # Notification flags
+    if options.get("notify", False):
+        parts.append("--notify")
+    if options.get("no_notify", False):
+        parts.append("--no-notify")
+
+    # Tags (multiple --tag KEY=VALUE)
+    tag_list = options.get("tag")
+    if tag_list:
+        for tag in tag_list:
+            parts.extend(["--tag", shlex.quote(str(tag))])
+    if options.get("tags"):
+        parts.extend(["--tags", shlex.quote(str(options["tags"]))])
+
+    # Environment variables (multiple --var KEY=VALUE)
+    var_list = options.get("var")
+    if var_list:
+        for var in var_list:
+            parts.extend(["--var", shlex.quote(str(var))])
+    if options.get("vars"):
+        parts.extend(["--vars", shlex.quote(str(options["vars"]))])
 
 
 def parse_options_from_ctx(ctx_obj: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:

--- a/tests/test_command_serialization.py
+++ b/tests/test_command_serialization.py
@@ -6,7 +6,7 @@ import sys
 
 sys.path.insert(0, "/g/data/a56/software/qsub_tools")
 
-from qxub.execution_context import ExecutionContext
+from qxub.execution.context import ExecutionContext
 from qxub.remote.command_builder import build_remote_command
 
 
@@ -65,6 +65,63 @@ def test_command_serialization():
     assert "--dry" in result
     assert "-vv" in result
     assert "echo hello" in result
+
+    # Test 5: GPU options
+    print("\n5. GPU options:")
+    ctx = ExecutionContext("conda", "ml-env", "conda")
+    options = {"gpus": 2, "gpu_type": "a100", "queue": "auto"}
+    command = ["python", "train.py"]
+    result = build_remote_command(ctx, options, command)
+    print(f"   Command: {result}")
+    assert "--gpus 2" in result
+    assert "--gpu-type a100" in result
+
+    # Test 6: Internet connectivity
+    print("\n6. Internet connectivity:")
+    ctx = ExecutionContext("default", None, "default")
+    options = {"internet": True}
+    command = ["curl", "https://example.com"]
+    result = build_remote_command(ctx, options, command)
+    print(f"   Command: {result}")
+    assert "--internet" in result
+
+    # Test 7: Tags and environment variables
+    print("\n7. Tags and environment variables:")
+    ctx = ExecutionContext("conda", "analysis", "conda")
+    options = {
+        "tag": ("rule=align", "workflow=brca"),
+        "tags": "step=1,batch=morning",
+        "var": ("FOO=bar", "BAZ=qux"),
+        "vars": "X=1,Y=2",
+    }
+    command = ["python", "run.py"]
+    result = build_remote_command(ctx, options, command)
+    print(f"   Command: {result}")
+    assert "--tag rule=align" in result
+    assert "--tag workflow=brca" in result
+    assert "--tags" in result
+    assert "--var FOO=bar" in result
+    assert "--var BAZ=qux" in result
+    assert "--vars" in result
+
+    # Test 8: Notification and log-dir options
+    print("\n8. Notification and log-dir options:")
+    ctx = ExecutionContext("default", None, "default")
+    options = {"notify": True, "log_dir": "/scratch/logs"}
+    command = ["hostname"]
+    result = build_remote_command(ctx, options, command)
+    print(f"   Command: {result}")
+    assert "--notify" in result
+    assert "--log-dir" in result
+
+    # Test 9: --no-notify flag
+    print("\n9. --no-notify flag:")
+    ctx = ExecutionContext("default", None, "default")
+    options = {"no_notify": True}
+    command = ["hostname"]
+    result = build_remote_command(ctx, options, command)
+    print(f"   Command: {result}")
+    assert "--no-notify" in result
 
     print("\n✅ All serialization tests passed!")
 


### PR DESCRIPTION
## Problem

The remote command builder (`qxub/remote/command_builder.py`) was silently dropping several `qxub exec` options when delegating jobs to a remote system via SSH. Any option not explicitly serialized was lost.

## Missing options (now fixed)

| Option | Type | Purpose |
|---|---|---|
| `--internet` | flag | Require internet-capable queue |
| `--gpus` | int | GPU count |
| `--gpu-type` | str | GPU type for queue selection |
| `--log-dir` | str | Log directory override |
| `--notify` | flag | Enable notifications |
| `--no-notify` | flag | Disable notifications |
| `--tag` | multiple | Job tags (KEY=VALUE) |
| `--tags` | str | Comma-separated tags |
| `--var` | multiple | Environment variables (KEY=VALUE) |
| `--vars` | str | Comma-separated env vars |

## Changes

- **`qxub/remote/command_builder.py`**: Added serialization for all missing options across `_add_cli_options`, `_add_workflow_options`, and `_add_job_options`.
- **`tests/test_command_serialization.py`**: Added 5 new test cases covering GPUs, internet, tags, env vars, notifications, and log-dir. Fixed stale import (`execution_context` → `execution.context`).