### PR TITLE
feat: add hostname to job audit trail in PBS templates

### DIFF
--- a/qxub/jobscripts/qconda.pbs
+++ b/qxub/jobscripts/qconda.pbs
@@ -12,6 +12,7 @@ echo "🐍 Conda environment: $env"
 echo "🔖 qxub version: ${qxub_version:-unknown}"
 echo "📦 qxub path: ${qxub_path:-unknown}"
 echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
+echo "🏠 Hostname: $(hostname)"
 
 # Decode base64 encoded commands
 if [ -n "$cmd_b64" ]; then

--- a/qxub/jobscripts/qconda_mod.pbs
+++ b/qxub/jobscripts/qconda_mod.pbs
@@ -13,6 +13,7 @@ echo "🐍 Conda environment: $env"
 echo "🔖 qxub version: ${qxub_version:-unknown}"
 echo "📦 qxub path: ${qxub_path:-unknown}"
 echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
+echo "🏠 Hostname: $(hostname)"
 
 # Decode base64 encoded commands
 if [ -n "$cmd_b64" ]; then

--- a/qxub/jobscripts/qdefault.pbs
+++ b/qxub/jobscripts/qdefault.pbs
@@ -12,6 +12,7 @@ echo "🔧 Default execution (no environment activation)"
 echo "🔖 qxub version: ${qxub_version:-unknown}"
 echo "📦 qxub path: ${qxub_path:-unknown}"
 echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
+echo "🏠 Hostname: $(hostname)"
 
 # Decode base64 encoded commands
 if [ -n "$cmd_b64" ]; then

--- a/qxub/jobscripts/qmod.pbs
+++ b/qxub/jobscripts/qmod.pbs
@@ -12,6 +12,7 @@ echo "📦 Modules to load: $mods"
 echo "🔖 qxub version: ${qxub_version:-unknown}"
 echo "📦 qxub path: ${qxub_path:-unknown}"
 echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
+echo "🏠 Hostname: $(hostname)"
 
 # Create status directory for monitoring
 STATUS_DIR="${out%/*}/status"

--- a/qxub/jobscripts/qsing.pbs
+++ b/qxub/jobscripts/qsing.pbs
@@ -13,6 +13,7 @@ echo "⚙️  Singularity options: $sing_options"
 echo "🔖 qxub version: ${qxub_version:-unknown}"
 echo "📦 qxub path: ${qxub_path:-unknown}"
 echo "🖥️  Submitted from: ${qxub_submit_host:-unknown}"
+echo "🏠 Hostname: $(hostname)"
 
 # Create status directory for monitoring
 STATUS_DIR="${out%/*}/status"


### PR DESCRIPTION
Adds `🏠 Hostname: $(hostname)` to the audit trail in all 5 PBS job script templates.

This prints the compute node name (e.g. `gadi-cpu-clx-1234`) in job output, making it easier to debug queue routing and internet connectivity issues.